### PR TITLE
100% correct test for uap-core v0.10.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,247 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "ac4132ad78082518ec2037ae5770b6e796f7f956"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.27.0"
+
+[[Crayons]]
+git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.4"
+
+[[DataAPI]]
+git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.6.0"
+
+[[DataFrames]]
+deps = ["Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrettyTables", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "6e5452d9cf401ed9048e1cde93815be53d951079"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.0.2"
+
+[[DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.9"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.2"
+
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[InvertedIndices]]
+deps = ["Test"]
+git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.0.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "4ea90bd5d3985ae1f9a908bd4500ae88921c5ce7"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.0.0"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OrderedCollections]]
+git-tree-sha1 = "4fa2ba51070ec13fcc7517db714445b4ab986bdf"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.0"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "cde4ce9d6f33219465b55162811d8de8139c0414"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.2.1"
+
+[[PrettyTables]]
+deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
+git-tree-sha1 = "b60494adf99652d220cdef46f8a32232182cc22d"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "1.0.1"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+git-tree-sha1 = "57d8440b0c7d98fc4f889e478e80f268d534c9d5"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.0.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "2ec1962eba973f383239da22e75218565c390a96"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.0.0"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "c9d2d262e9a327be1f35844df25fe4561d258dc9"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.4.2"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[YAML]]
+deps = ["Base64", "Dates", "Printf"]
+git-tree-sha1 = "78c02bd295bbd0ca330f95e07ccdfcb69f6cbcd4"
+uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+version = "0.4.6"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,8 @@
+name = "UAParser"
+uuid = "837028c2-ff35-4e48-8e90-1cf91023c992"
+authors = ["melonedo <44501064+melonedo@users.noreply.github.com>"]
+version = "2.0.1"
+
+[deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UAParser"
 uuid = "837028c2-ff35-4e48-8e90-1cf91023c992"
 authors = ["melonedo <44501064+melonedo@users.noreply.github.com>"]
-version = "2.0.1"
+version = "0.7.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1,17 +1,63 @@
 user_agent_parsers:
   #### SPECIAL CASES TOP ####
 
+  # ESRI Server products
+  - regex: '(GeoEvent Server) (\d+)(?:\.(\d+)(?:\.(\d+)|)|)'
+
+  # ESRI ArcGIS Desktop Products
+  - regex: '(ArcGIS Pro)(?: (\d+)\.(\d+)\.([^ ]+)|)'
+
+  - regex: 'ArcGIS Client Using WinInet'
+    family_replacement: 'ArcMap'
+
+  - regex: '(OperationsDashboard)-(?:Windows)-(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Operations Dashboard for ArcGIS'
+
+  - regex: '(arcgisearth)/(\d+)\.(\d+)(?:\.(\d+)|)'
+    family_replacement: 'ArcGIS Earth'
+
+  - regex: 'com.esri.(earth).phone/(\d+)\.(\d+)(?:\.(\d+)|)'
+    family_replacement: 'ArcGIS Earth'
+
+  # ESRI ArcGIS Mobile Products
+  - regex: '(arcgis-explorer)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Explorer for ArcGIS'
+
+  - regex: 'arcgis-(collector|aurora)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Collector for ArcGIS'
+
+  - regex: '(arcgis-workforce)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Workforce for ArcGIS'
+
+  - regex: '(Collector|Explorer|Workforce)-(?:Android|iOS)-(\d+)\.(\d+)(?:\.(\d+)|)'
+    family_replacement: '$1 for ArcGIS'
+
+  - regex: '(Explorer|Collector)/(\d+) CFNetwork'
+    family_replacement: '$1 for ArcGIS'
+
+  # ESRI ArcGIS Runtimes
+  - regex: 'ArcGISRuntime-(Android|iOS|NET|Qt)/(\d+)\.(\d+)(?:\.(\d+)|)'
+    family_replacement: 'ArcGIS Runtime SDK for $1'
+
+  - regex: 'ArcGIS\.?(iOS|Android|NET|Qt)(?:-|\.)(\d+)\.(\d+)(?:\.(\d+)|)'
+    family_replacement: 'ArcGIS Runtime SDK for $1'
+
+  - regex: 'ArcGIS\.Runtime\.(Qt)\.(\d+)\.(\d+)(?:\.(\d+)|)'
+    family_replacement: 'ArcGIS Runtime SDK for $1'
+
   # CFNetwork Podcast catcher Applications
+  - regex: '^(Luminary)[Stage]+/(\d+) CFNetwork'
   - regex: '(ESPN)[%20| ]+Radio/(\d+)\.(\d+)\.(\d+) CFNetwork'
   - regex: '(Antenna)/(\d+) CFNetwork'
     family_replacement: 'AntennaPod'
   - regex: '(TopPodcasts)Pro/(\d+) CFNetwork'
   - regex: '(MusicDownloader)Lite/(\d+)\.(\d+)\.(\d+) CFNetwork'
-  - regex: '^(.*)-iPad\/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|) CFNetwork'
-  - regex: '^(.*)-iPhone/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|) CFNetwork'
-  - regex: '^(.*)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|) CFNetwork'
+  - regex: '^(.{0,200})-iPad\/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|) CFNetwork'
+  - regex: '^(.{0,200})-iPhone/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|) CFNetwork'
+  - regex: '^(.{0,200})/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|) CFNetwork'
 
   # Podcast catchers
+  - regex: '^(Luminary)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
   - regex: '(espn\.go)'
     family_replacement: 'ESPN'
   - regex: '(espnradio\.com)'
@@ -27,11 +73,18 @@ user_agent_parsers:
     family_replacement: 'CFNetwork'
 
   # Pingdom
-  - regex: '(Pingdom.com_bot_version_)(\d+)\.(\d+)'
+  - regex: '(Pingdom\.com_bot_version_)(\d+)\.(\d+)'
     family_replacement: 'PingdomBot'
   # 'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34'
   - regex: '(PingdomTMS)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'PingdomBot'
+
+  # PTST / WebPageTest.org crawlers
+  - regex: ' (PTST)/(\d+)(?:\.(\d+)|)$'
+    family_replacement: 'WebPageTest.org bot'
+
+  # Datanyze.com spider
+  - regex: 'X11; (Datanyze); Linux'
 
   # New Relic Pinger
   - regex: '(NewRelicPinger)/(\d+)\.(\d+)'
@@ -40,6 +93,10 @@ user_agent_parsers:
   # Tableau
   - regex: '(Tableau)/(\d+)\.(\d+)'
     family_replacement: 'Tableau'
+
+  # Adobe CreativeCloud
+  - regex: 'AppleWebKit/\d{1,10}\.\d{1,10}.{0,200} Safari.{0,200} (CreativeCloud)/(\d+)\.(\d+).(\d+)'
+    family_replacement: 'Adobe CreativeCloud'
 
   # Salesforce
   - regex: '(Salesforce)(?:.)\/(\d+)\.(\d?)'
@@ -53,53 +110,78 @@ user_agent_parsers:
     family_replacement: 'FacebookBot'
 
   # Google Plus
-  - regex: 'Google.*/\+/web/snippet'
+  - regex: 'Google.{0,50}/\+/web/snippet'
     family_replacement: 'GooglePlusBot'
 
   # Gmail
-  - regex: 'via ggpht.com GoogleImageProxy'
+  - regex: 'via ggpht\.com GoogleImageProxy'
     family_replacement: 'GmailImageProxy'
 
   # Yahoo
-  - regex: 'YahooMailProxy; https://help.yahoo.com/kb/yahoo-mail-proxy-SLN28749.html'
+  - regex: 'YahooMailProxy; https://help\.yahoo\.com/kb/yahoo-mail-proxy-SLN28749\.html'
     family_replacement: 'YahooMailProxy'
 
   # Twitter
   - regex: '(Twitterbot)/(\d+)\.(\d+)'
-    family_replacement: 'TwitterBot'
+    family_replacement: 'Twitterbot'
 
-  # Bots Pattern '/name-0.0'
+  # Bots Pattern 'name/0.0.0'
   - regex: '/((?:Ant-|)Nutch|[A-z]+[Bb]ot|[A-z]+[Ss]pider|Axtaris|fetchurl|Isara|ShopSalad|Tailsweep)[ \-](\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
-  # Bots Pattern 'name/0.0'
-  - regex: '\b(008|Altresium|Argus|BaiduMobaider|BoardReader|DNSGroup|DataparkSearch|EDI|Goodzer|Grub|INGRID|Infohelfer|LinkedInBot|LOOQ|Nutch|PathDefender|Peew|PostPost|Steeler|Twitterbot|VSE|WebCrunch|WebZIP|Y!J-BR[A-Z]|YahooSeeker|envolk|sproose|wminer)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
+  # Bots Pattern 'name/0.0.0'
+  - regex: '\b(008|Altresium|Argus|BaiduMobaider|BoardReader|DNSGroup|DataparkSearch|EDI|Goodzer|Grub|INGRID|Infohelfer|LinkedInBot|LOOQ|Nutch|OgScrper|Pandora|PathDefender|Peew|PostPost|Steeler|Twitterbot|VSE|WebCrunch|WebZIP|Y!J-BR[A-Z]|YahooSeeker|envolk|sproose|wminer)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
 
   # MSIECrawler
-  - regex: '(MSIE) (\d+)\.(\d+)([a-z]\d|[a-z]|);.* MSIECrawler'
+  - regex: '(MSIE) (\d+)\.(\d+)([a-z]\d|[a-z]|);.{0,200} MSIECrawler'
     family_replacement: 'MSIECrawler'
 
   # DAVdroid
   - regex: '(DAVdroid)/(\d+)\.(\d+)(?:\.(\d+)|)'
 
   # Downloader ...
-  - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|Go-http-client|scalaj-http|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP|okhttp|aihttp|reqwest)(?:[ /](\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+  - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|Go-http-client|scalaj-http|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP|okhttp|aihttp|reqwest|axios|unirest-(?:java|python|ruby|nodejs|php|net))(?:[ /](\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
 
   # Pinterestbot
   - regex: '(Pinterest(?:bot|))/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)[;\s(]+\+https://www.pinterest.com/bot.html'
     family_replacement: 'Pinterestbot'
 
   # Bots
-  - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]{1,30}-Agent|AdsBot-Google(?:-[a-z]{1,30}|)|altavista|AppEngine-Google|archive.{0,30}\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]{1,30})(?:-[A-Za-z]{1,30}|)|bingbot|BingPreview|blitzbot|BlogBridge|Bloglovin|BoardReader Blog Indexer|BoardReader Favicon Fetcher|boitho.com-dc|BotSeer|BUbiNG|\b\w{0,30}favicon\w{0,30}\b|\bYeti(?:-[a-z]{1,30}|)|Catchpoint(?: bot|)|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher|)|Feed Seeker Bot|Feedbin|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]{1,30}-|)Googlebot(?:-[a-zA-Z]{1,30}|)|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile|)|IconSurf|IlTrovatore(?:-Setaccio|)|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]{1,30}Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masscan|masidani_bot|Mediapartners-Google|Microsoft .{0,30} Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media {0,2}|)|msrbot|Mtps Feed Aggregation System|netresearch|Netvibes|NewsGator[^/]{0,30}|^NING|Nutch[^/]{0,30}|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Qwantify|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|SemrushBot|Simpy|SimplePie|SEOstats|SimpleRSS|SiteCon|Slackbot-LinkExpanding|Slack-ImgProxy|Slurp|snappy|Speedy Spider|Squrl Java|Stringer|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|Tiny Tiny RSS|TwitterBot|WhatsApp|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]{1,30}|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s|) Link Sleuth|Xerka [A-z]{1,30}Bot|yacy(?:bot|)|YahooSeeker|Yahoo! Slurp|Yandex\w{1,30}|YodaoBot(?:-[A-z]{1,30}|)|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+)|)|)|)'
+  - regex: '(CSimpleSpider|Cityreview Robot|CrawlDaddy|CrawlFire|Finderbots|Index crawler|Job Roboter|KiwiStatus Spider|Lijit Crawler|QuerySeekerSpider|ScollSpider|Trends Crawler|USyd-NLP-Spider|SiteCat Webbot|BotName\/\$BotVersion|123metaspider-Bot|1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]{1,30}-Agent|AdsBot-Google(?:-[a-z]{1,30}|)|altavista|AppEngine-Google|archive.{0,30}\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]{1,30})(?:-[A-Za-z]{1,30}|)|bingbot|BingPreview|blitzbot|BlogBridge|Bloglovin|BoardReader Blog Indexer|BoardReader Favicon Fetcher|boitho.com-dc|BotSeer|BUbiNG|\b\w{0,30}favicon\w{0,30}\b|\bYeti(?:-[a-z]{1,30}|)|Catchpoint(?: bot|)|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher|)|Feed Seeker Bot|Feedbin|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]{1,30}-|)Googlebot(?:-[a-zA-Z]{1,30}|)|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile|)|IconSurf|IlTrovatore(?:-Setaccio|)|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]{1,30}Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masscan|masidani_bot|Mediapartners-Google|Microsoft .{0,30} Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media {0,2}|)|msrbot|Mtps Feed Aggregation System|netresearch|Netvibes|NewsGator[^/]{0,30}|^NING|Nutch[^/]{0,30}|Nymesis|ObjectsSearch|OgScrper|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PHPCrawl|PlantyNet_WebRobot|Pompos|Qwantify|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|SemrushBot|Simpy|SimplePie|SEOstats|SimpleRSS|SiteCon|Slackbot-LinkExpanding|Slack-ImgProxy|Slurp|snappy|Speedy Spider|Squrl Java|Stringer|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|Tiny Tiny RSS|Twitterbot|WhatsApp|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]{1,30}|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s|) Link Sleuth|Xerka [A-z]{1,30}Bot|yacy(?:bot|)|YahooSeeker|Yahoo! Slurp|Yandex\w{1,30}|YodaoBot(?:-[A-z]{1,30}|)|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg|ArcGIS Hub Indexer)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+)|)|)|)'
 
   # AWS S3 Clients
   # must come before "Bots General matcher" to catch "boto"/"boto3" before "bot"
-  - regex: '\b(Boto3?|JetS3t|aws-(?:cli|sdk-(?:cpp|go|java|nodejs|ruby2?))|s3fs)/(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '\b(Boto3?|JetS3t|aws-(?:cli|sdk-(?:cpp|go|java|nodejs|ruby2?|dotnet-(?:\d{1,2}|core)))|s3fs)/(\d+)\.(\d+)(?:\.(\d+)|)'
+
+  # SAFE FME
+  - regex: '(FME)\/(\d+\.\d+)\.(\d+)\.(\d+)'
+
+  # QGIS
+  - regex: '(QGIS)\/(\d)\.?0?(\d{1,2})\.?0?(\d{1,2})'
+
+  # JOSM
+  - regex: '(JOSM)/(\d+)\.(\d+)'
+
+  # Tygron Platform
+  - regex: '(Tygron Platform) \((\d+)\.(\d+)\.(\d+(?:\.\d+| RC \d+\.\d+))'
+
+  # Facebook
+  # Must come before "Bots General matcher" to catch OrangeBotswana
+  # Facebook Messenger must go before Facebook
+  - regex: '\[(FBAN/MessengerForiOS|FB_IAB/MESSENGER);FBAV/(\d+)(?:\.(\d+)(?:\.(\d+)(?:\.(\d+)|)|)|)'
+
+    family_replacement: 'Facebook Messenger'
+  # Facebook
+  - regex: '\[FB.{0,300};(FBAV)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
+    family_replacement: 'Facebook'
+  # Sometimes Facebook does not specify a version (FBAV)
+  - regex: '\[FB.{0,300};'
+    family_replacement: 'Facebook'
 
   # Bots General matcher 'name/0.0'
-  - regex: '(?:\/[A-Za-z0-9\.]+|) *([A-Za-z0-9 \-_\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*))/(\d+)(?:\.(\d+)(?:\.(\d+)|)|)'
-  # Bots General matcher 'name 0.0'
-  - regex: '(?:\/[A-Za-z0-9\.]+|) *([A-Za-z0-9 _\!\[\]:]*(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]*)) (\d+)(?:\.(\d+)(?:\.(\d+)|)|)'
-  # Bots containing spider|scrape|bot(but not CUBOT)|Crawl
-  - regex: '((?:[A-z0-9]+|[A-z\-]+ ?|)(?: the |)(?:[Ss][Pp][Ii][Dd][Ee][Rr]|[Ss]crape|[A-Za-z0-9-]*(?:[^C][^Uu])[Bb]ot|[Cc][Rr][Aa][Ww][Ll])[A-z0-9]*)(?:(?:[ /]| v)(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+  - regex: '^.{0,200}?(?:\/[A-Za-z0-9\.]{0,50}|) {0,2}([A-Za-z0-9 \-_\!\[\]:]{0,50}(?:[Aa]rchiver|[Ii]ndexer|[Ss]craper|[Bb]ot|[Ss]pider|[Cc]rawl[a-z]{0,50}))[/ ](\d+)(?:\.(\d+)(?:\.(\d+)|)|)'
+  # Bots containing bot(but not CUBOT)
+  - regex: '^.{0,200}?((?:[A-Za-z][A-Za-z0-9 -]{0,50}|)[^C][^Uu][Bb]ot)\b(?:(?:[ /]| v)(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+  # Bots containing spider|scrape|Crawl
+  - regex: '^.{0,200}?((?:[A-z0-9]{1,50}|[A-z\-]{1,50} ?|)(?: the |)(?:[Ss][Pp][Ii][Dd][Ee][Rr]|[Ss]crape|[Cc][Rr][Aa][Ww][Ll])[A-z0-9]{0,50})(?:(?:[ /]| v)(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
 
   # HbbTV standard defines what features the browser should understand.
   # but it's like targeting "HTML5 browsers", effective browser support depends on the model
@@ -109,29 +191,34 @@ user_agent_parsers:
   # must go before Firefox to catch Chimera/SeaMonkey/Camino/Waterfox
   - regex: '(Chimera|SeaMonkey|Camino|Waterfox)/(\d+)\.(\d+)\.?([ab]?\d+[a-z]*|)'
 
-  # Social Networks
-  # Facebook Messenger must go before Facebook
-  - regex: '\[(FBAN/MessengerForiOS|FB_IAB/MESSENGER);FBAV/(\d+)(?:\.(\d+)(?:\.(\d+)|)|)'
-    family_replacement: 'Facebook Messenger'
-  # Facebook
-  - regex: '\[FB.*;(FBAV)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
-    family_replacement: 'Facebook'
-  # Sometimes Facebook does not specify a version (FBAV)
-  - regex: '\[FB.*;'
-    family_replacement: 'Facebook'
+  # must be before Firefox / Gecko to catch SailfishBrowser properly
+  - regex: '(SailfishBrowser)/(\d+)\.(\d+)(?:\.(\d+)|)'
+    family_replacement: 'Sailfish Browser'
+
+  # Social Networks (non-Facebook)
   # Pinterest
-  - regex: '\[(Pinterest)/[^\]]+\]'
+  - regex: '\[(Pinterest)/[^\]]{1,50}\]'
   - regex: '(Pinterest)(?: for Android(?: Tablet|)|)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
   # Instagram app
-  - regex: 'Mozilla.*Mobile.*(Instagram).(\d+)\.(\d+)\.(\d+)'
+  - regex: 'Mozilla.{1,200}Mobile.{1,100}(Instagram).(\d+)\.(\d+)\.(\d+)'
   # Flipboard app
-  - regex: 'Mozilla.*Mobile.*(Flipboard).(\d+)\.(\d+)\.(\d+)'
+  - regex: 'Mozilla.{1,200}Mobile.{1,100}(Flipboard).(\d+)\.(\d+)\.(\d+)'
   # Flipboard-briefing app
-  - regex: 'Mozilla.*Mobile.*(Flipboard-Briefing).(\d+)\.(\d+)\.(\d+)'
+  - regex: 'Mozilla.{1,200}Mobile.{1,100}(Flipboard-Briefing).(\d+)\.(\d+)\.(\d+)'
   # Onefootball app
-  - regex: 'Mozilla.*Mobile.*(Onefootball)\/Android.(\d+)\.(\d+)\.(\d+)'
+  - regex: 'Mozilla.{1,200}Mobile.{1,100}(Onefootball)\/Android.(\d+)\.(\d+)\.(\d+)'
   # Snapchat
-  - regex: '(Snapchat)\/(\d+)\.(\d+)\.(\d+).(\d+)'
+  - regex: '(Snapchat)\/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+  # Twitter
+  - regex: '(Twitter for (?:iPhone|iPad)|TwitterAndroid)(?:\/(\d+)\.(\d+)|)'
+    family_replacement: 'Twitter'
+
+  # aspiegel.com spider (owned by Huawei)
+  - regex: 'Mozilla.{1,100}Mobile.{1,100}AspiegelBot'
+    family_replacement: 'Spider'
+
+  - regex: 'AspiegelBot'
+    family_replacement: 'Spider'
 
   # Basilisk
   - regex: '(Firefox)/(\d+)\.(\d+) Basilisk/(\d+)'
@@ -148,7 +235,7 @@ user_agent_parsers:
     family_replacement: 'Firefox Mobile'
   - regex: '(Fennec)/(\d+)\.(\d+)'
     family_replacement: 'Firefox Mobile'
-  - regex: '(?:Mobile|Tablet);.*(Firefox)/(\d+)\.(\d+)'
+  - regex: '(?:Mobile|Tablet);.{0,200}(Firefox)/(\d+)\.(\d+)'
     family_replacement: 'Firefox Mobile'
   - regex: '(Namoroka|Shiretoko|Minefield)/(\d+)\.(\d+)\.(\d+(?:pre|))'
     family_replacement: 'Firefox ($1)'
@@ -162,7 +249,7 @@ user_agent_parsers:
     family_replacement: 'Firefox Beta'
   - regex: '(Namoroka|Shiretoko|Minefield)/(\d+)\.(\d+)([ab]\d+[a-z]*|)'
     family_replacement: 'Firefox ($1)'
-  - regex: '(Firefox).*Tablet browser (\d+)\.(\d+)\.(\d+)'
+  - regex: '(Firefox).{0,200}Tablet browser (\d+)\.(\d+)\.(\d+)'
     family_replacement: 'MicroB'
   - regex: '(MozillaDeveloperPreview)/(\d+)\.(\d+)([ab]\d+[a-z]*|)'
   - regex: '(FxiOS)/(\d+)\.(\d+)(\.(\d+)|)(\.(\d+)|)'
@@ -194,24 +281,24 @@ user_agent_parsers:
 
   # Opera will stop at 9.80 and hide the real version in the Version string.
   # see: http://dev.opera.com/articles/view/opera-ua-string-changes/
-  - regex: '(Opera Tablet).*Version/(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(Opera Tablet).{0,200}Version/(\d+)\.(\d+)(?:\.(\d+)|)'
   - regex: '(Opera Mini)(?:/att|)/?(\d+|)(?:\.(\d+)|)(?:\.(\d+)|)'
-  - regex: '(Opera)/.+Opera Mobi.+Version/(\d+)\.(\d+)'
+  - regex: '(Opera)/.{1,100}Opera Mobi.{1,100}Version/(\d+)\.(\d+)'
     family_replacement: 'Opera Mobile'
-  - regex: '(Opera)/(\d+)\.(\d+).+Opera Mobi'
+  - regex: '(Opera)/(\d+)\.(\d+).{1,100}Opera Mobi'
     family_replacement: 'Opera Mobile'
-  - regex: 'Opera Mobi.+(Opera)(?:/|\s+)(\d+)\.(\d+)'
+  - regex: 'Opera Mobi.{1,100}(Opera)(?:/|\s+)(\d+)\.(\d+)'
     family_replacement: 'Opera Mobile'
   - regex: 'Opera Mobi'
     family_replacement: 'Opera Mobile'
-  - regex: '(Opera)/9.80.*Version/(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(Opera)/9.80.{0,200}Version/(\d+)\.(\d+)(?:\.(\d+)|)'
 
   # Opera 14 for Android uses a WebKit render engine.
-  - regex: '(?:Mobile Safari).*(OPR)/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(?:Mobile Safari).{1,300}(OPR)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Opera Mobile'
 
   # Opera >=15 for Desktop is similar to Chrome but includes an "OPR" Version string.
-  - regex: '(?:Chrome).*(OPR)/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(?:Chrome).{1,300}(OPR)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Opera'
 
   # Opera Coast
@@ -223,7 +310,7 @@ user_agent_parsers:
     family_replacement: 'Opera Mini'
 
   # Opera Neon
-  - regex: 'Chrome/.+( MMS)/(\d+).(\d+).(\d+)'
+  - regex: 'Chrome/.{1,200}( MMS)/(\d+).(\d+).(\d+)'
     family_replacement: 'Opera Neon'
 
   # Palm WebOS looks a lot like Safari.
@@ -270,7 +357,7 @@ user_agent_parsers:
 
   - regex: '(Symphony) (\d+).(\d+)'
 
-  - regex: 'PLAYSTATION 3.+WebKit'
+  - regex: 'PLAYSTATION 3.{1,200}WebKit'
     family_replacement: 'NetFront NX'
   - regex: 'PLAYSTATION 3'
     family_replacement: 'NetFront'
@@ -279,7 +366,7 @@ user_agent_parsers:
   - regex: '(PlayStation Vita)'
     family_replacement: 'NetFront NX'
 
-  - regex: 'AppleWebKit.+ (NX)/(\d+)\.(\d+)\.(\d+)'
+  - regex: 'AppleWebKit.{1,200} (NX)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'NetFront NX'
   - regex: '(Nintendo 3DS)'
     family_replacement: 'NetFront NX'
@@ -292,7 +379,9 @@ user_agent_parsers:
   - regex: '(Puffin)/(\d+)\.(\d+)(?:\.(\d+)|)'
 
   # Edge Mobile
-  - regex: 'Windows Phone .*(Edge)/(\d+)\.(\d+)'
+  - regex: 'Windows Phone .{0,200}(Edge)/(\d+)\.(\d+)'
+    family_replacement: 'Edge Mobile'
+  - regex: '(EdgiOS|EdgA)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Edge Mobile'
 
   # Samsung Internet (based on Chrome, but lacking some features)
@@ -303,7 +392,7 @@ user_agent_parsers:
   - regex: '(SznProhlizec)/(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Seznam prohlížeč'
 
-  # Coc Coc browser, based on Chrome (used in Vietnam)
+  # Coc Coc browser, based on Chrome (used in Vietnam)
   - regex: '(coc_coc_browser)/(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Coc Coc'
 
@@ -320,10 +409,47 @@ user_agent_parsers:
   # Crosswalk must go before Mobile Chrome for Android
   - regex: '(Crosswalk)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
 
+  # LINE https://line.me/en/
+  # Must go before Mobile Chrome for Android
+  - regex: '(Line)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'LINE'
+
+  # MiuiBrowser should got before Mobile Chrome for Android
+  - regex: '(MiuiBrowser)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'MiuiBrowser'
+
+  # Mint Browser should got before Mobile Chrome for Android
+  - regex: '(Mint Browser)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Mint Browser'
+
+  # TopBuzz Android must go before Chrome Mobile WebView
+  - regex: '(TopBuzz)/(\d+).(\d+).(\d+)'
+    family_replacement: 'TopBuzz'
+
+  # Google Search App on Android, eg:
+  - regex: 'Mozilla.{1,200}Android.{1,200}(GSA)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Google'
+
+  # QQ Browsers
+  - regex: '(MQQBrowser/Mini)(?:(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+    family_replacement: 'QQ Browser Mini'
+  - regex: '(MQQBrowser)(?:/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+    family_replacement: 'QQ Browser Mobile'
+  - regex: '(QQBrowser)(?:/(\d+)(?:\.(\d+)\.(\d+)(?:\.(\d+)|)|)|)'
+    family_replacement: 'QQ Browser'
+
+  # DuckDuckGo
+  - regex: 'Mobile.{0,200}(DuckDuckGo)/(\d+)'
+    family_replacement: 'DuckDuckGo Mobile'
+
+  # Tenta Browser
+  - regex: '(Tenta/)(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Tenta Browser'
+
   # Chrome Mobile
-  - regex: 'Version/.+(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+  - regex: 'Version/.{1,300}(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile WebView'
-  - regex: '; wv\).+(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+  - regex: '; wv\).{1,300}(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile WebView'
   - regex: '(CrMo)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile'
@@ -331,7 +457,7 @@ user_agent_parsers:
     family_replacement: 'Chrome Mobile iOS'
   - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+) Mobile(?:[ /]|$)'
     family_replacement: 'Chrome Mobile'
-  - regex: ' Mobile .*(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+  - regex: ' Mobile .{1,300}(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Chrome Mobile'
 
   # Chrome Frame must come before MSIE.
@@ -346,17 +472,12 @@ user_agent_parsers:
   - regex: '(SE 2\.X) MetaSr (\d+)\.(\d+)'
     family_replacement: 'Sogou Explorer'
 
-  # QQ Browsers
-  - regex: '(MQQBrowser/Mini)(?:(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
-    family_replacement: 'QQ Browser Mini'
-  - regex: '(MQQBrowser)(?:/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
-    family_replacement: 'QQ Browser Mobile'
-  - regex: '(QQBrowser)(?:/(\d+)(?:\.(\d+)\.(\d+)(?:\.(\d+)|)|)|)'
-    family_replacement: 'QQ Browser'
-
   # Rackspace Monitoring
   - regex: '(Rackspace Monitoring)/(\d+)\.(\d+)'
     family_replacement: 'RackspaceBot'
+
+  # PRTG Network Monitoring
+  - regex: '(PRTG Network Monitor)'
 
   # PyAMF
   - regex: '(PyAMF)/(\d+)\.(\d+)\.(\d+)'
@@ -366,7 +487,7 @@ user_agent_parsers:
     family_replacement: 'Yandex Browser'
 
   # Mail.ru Amigo/Internet Browser (Chromium-based)
-  - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+).* MRCHROME'
+  - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+).{0,100} MRCHROME'
     family_replacement: 'Mail.ru Chromium Browser'
 
   # AOL Browser (IE-based)
@@ -385,6 +506,16 @@ user_agent_parsers:
 
   - regex: '(Whale)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Whale'
+
+  # 1Password
+  - regex: '(1Password)/(\d+)\.(\d+)\.(\d+)'
+
+  # Ghost
+  # @ref: http://www.ghost.org
+  - regex: '(Ghost)/(\d+)\.(\d+)\.(\d+)'
+
+  # Palo Alto GlobalProtect Linux
+  - regex: 'PAN (GlobalProtect)/(\d+)\.(\d+)\.(\d+) .{1,100} \(X11; Linux x86_64\)'
 
   #### END SPECIAL CASES TOP ####
 
@@ -419,12 +550,15 @@ user_agent_parsers:
     v1_replacement: '2013'
 
   # Outlook 2016
-  - regex: 'Microsoft Outlook (?:Mail )?16\.\d+\.\d+'
+  - regex: 'Microsoft Outlook (?:Mail )?16\.\d+\.\d+|MSOffice 16'
     family_replacement: 'Outlook'
     v1_replacement: '2016'
 
+  # Word 2014
+  - regex: 'Microsoft Office (Word) 2014'
+
   # Windows Live Mail
-  - regex: 'Outlook-Express\/7\.0.*'
+  - regex: 'Outlook-Express\/7\.0'
     family_replacement: 'Windows Live Mail'
 
   # Apple Air Mail
@@ -446,18 +580,25 @@ user_agent_parsers:
   - regex: '(Lotus-Notes)/(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Lotus Notes'
 
+  # Superhuman Mail Client
+  # @ref: https://www.superhuman.com
+  - regex: 'Superhuman'
+    family_replacement: 'Superhuman'
+
   # Vivaldi uses "Vivaldi"
   - regex: '(Vivaldi)/(\d+)\.(\d+)\.(\d+)'
 
   # Edge/major_version.minor_version
-  - regex: '(Edge)/(\d+)(?:\.(\d+)|)'
+  # Edge with chromium Edg/major_version.minor_version.patch.minor_patch
+  - regex: '(Edge?)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)(?:\.(\d+)|)'
+    family_replacement: 'Edge'
 
   # Brave Browser https://brave.com/
   - regex: '(brave)/(\d+)\.(\d+)\.(\d+) Chrome'
     family_replacement: 'Brave'
 
   # Iron Browser ~since version 50
-  - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)[\d.]* Iron[^/]'
+  - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)[\d.]{0,100} Iron[^/]'
     family_replacement: 'Iron'
 
   # Dolphin Browser
@@ -533,20 +674,20 @@ user_agent_parsers:
   - regex: '^(HTC) Streaming Player \S+ / \S+ / \S+ / (\d+)\.(\d+)(?:\.(\d+)|)'
   - regex: '^(Stitcher)/iOS'
   - regex: '^(Stitcher)/Android'
-  - regex: '^(VLC) .*version (\d+)\.(\d+)\.(\d+)'
+  - regex: '^(VLC) .{0,200}version (\d+)\.(\d+)\.(\d+)'
   - regex: ' (VLC) for'
   - regex: '(vlc)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'VLC'
-  - regex: '^(foobar)\S+/([^.\s]+)\.([^.\s]+|)\.?([^.\s]+|)'
-  - regex: '^(Clementine)\S+ ([^.\s]+)\.([^.\s]+|)\.?([^.\s]+|)'
-  - regex: '(amarok)/([^.\s]+)\.([^.\s]+|)\.?([^.\s]+|)'
+  - regex: '^(foobar)\S{1,10}/(\d+)\.(\d+|)\.?([\da-z]+|)'
+  - regex: '^(Clementine)\S{1,10} (\d+)\.(\d+|)\.?(\d+|)'
+  - regex: '(amarok)/(\d+)\.(\d+|)\.?(\d+|)'
     family_replacement: 'Amarok'
   - regex: '(Custom)-Feed Reader'
 
   # Browser major_version.minor_version.beta_version (space instead of slash)
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
   # Browser major_version.minor_version (space instead of slash)
-  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris|Microsoft SkyDriveSync|The Bat!) (\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris|Microsoft SkyDriveSync|The Bat!) (\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
 
   # Kindle WebKit
   - regex: '(Kindle)/(\d+)\.(\d+)'
@@ -573,7 +714,7 @@ user_agent_parsers:
 
   # desktop mode
   # http://www.anandtech.com/show/3982/windows-phone-7-review
-  - regex: '(MSIE) (\d+)\.(\d+).*XBLWP7'
+  - regex: '(MSIE) (\d+)\.(\d+).{0,100}XBLWP7'
     family_replacement: 'IE Large Screen'
 
   # Nextcloud desktop sync client
@@ -585,6 +726,21 @@ user_agent_parsers:
   # Nextcloud/Owncloud android client
   - regex: '(ownCloud-android)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'Owncloud'
+
+  # Skype for Business
+  - regex: '(OC)/(\d+)\.(\d+)\.(\d+)\.(\d+) \(Skype for Business\)'
+    family_replacement: 'Skype'
+
+  # OpenVAS Scanner
+  - regex: '(OpenVAS)(?:-VT)?(?:[ \/](\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+    family_replacement: 'OpenVAS Scanner'
+
+  # AnyConnect
+  - regex: '(AnyConnect)\/(\d+)(?:\.(\d+)(?:\.(\d+)|)|)'
+
+  # Monitis
+  - regex: 'compatible; monitis'
+    family_replacement: 'Monitis'
 
   #### END MAIN CASES ####
 
@@ -613,23 +769,29 @@ user_agent_parsers:
   - regex: '(BonEcho)/(\d+)\.(\d+)\.?([ab]?\d+|)'
     family_replacement: 'Bon Echo'
 
+    # topbuzz on IOS
+  - regex: '(TopBuzz) com.alex.NewsMaster/(\d+).(\d+).(\d+)'
+    family_replacement: 'TopBuzz'
+  - regex: '(TopBuzz) com.mobilesrepublic.newsrepublic/(\d+).(\d+).(\d+)'
+    family_replacement: 'TopBuzz'
+  - regex: '(TopBuzz) com.topbuzz.videoen/(\d+).(\d+).(\d+)'
+    family_replacement: 'TopBuzz'
+
   # @note: iOS / OSX Applications
-  - regex: '(iPod|iPhone|iPad).+GSA/(\d+)\.(\d+)\.(\d+) Mobile'
+  - regex: '(iPod|iPhone|iPad).{1,200}GSA/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|) Mobile'
     family_replacement: 'Google'
-  - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+)|).*[ +]Safari'
+  - regex: '(iPod|iPhone|iPad).{1,200}Version/(\d+)\.(\d+)(?:\.(\d+)|).{1,200}[ +]Safari'
     family_replacement: 'Mobile Safari'
-  - regex: '(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+)|).* AppleNews\/\d+\.\d+\.\d+?'
+  - regex: '(iPod|iPod touch|iPhone|iPad);.{0,30}CPU.{0,30}OS[ +](\d+)_(\d+)(?:_(\d+)|).{0,30} AppleNews\/\d+\.\d+(?:\.\d+|)'
     family_replacement: 'Mobile Safari UI/WKWebView'
-  - regex: '(iPod|iPhone|iPad).+Version/(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(iPod|iPhone|iPad).{1,200}Version/(\d+)\.(\d+)(?:\.(\d+)|)'
     family_replacement: 'Mobile Safari UI/WKWebView'
-  - regex: '(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+)|).*Mobile.*[ +]Safari'
+  - regex: '(iPod|iPod touch|iPhone|iPad).{0,200} Safari'
     family_replacement: 'Mobile Safari'
-  - regex: '(iPod|iPod touch|iPhone|iPad);.*CPU.*OS[ +](\d+)_(\d+)(?:_(\d+)|).*Mobile'
+  - regex: '(iPod|iPod touch|iPhone|iPad)'
     family_replacement: 'Mobile Safari UI/WKWebView'
-  - regex: '(iPod|iPhone|iPad).* Safari'
-    family_replacement: 'Mobile Safari'
-  - regex: '(iPod|iPhone|iPad)'
-    family_replacement: 'Mobile Safari UI/WKWebView'
+  - regex: '(Watch)(\d+),(\d+)'
+    family_replacement: 'Apple $1 App'
 
   ##########################
   # Outlook on iOS >= 2.62.0
@@ -675,9 +837,9 @@ user_agent_parsers:
   - regex: '(Nokia)[EN]?(\d+)'
 
   # BlackBerry devices
-  - regex: '(PlayBook).+RIM Tablet OS (\d+)\.(\d+)\.(\d+)'
+  - regex: '(PlayBook).{1,200}RIM Tablet OS (\d+)\.(\d+)\.(\d+)'
     family_replacement: 'BlackBerry WebKit'
-  - regex: '(Black[bB]erry|BB10).+Version/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(Black[bB]erry|BB10).{1,200}Version/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'BlackBerry WebKit'
   - regex: '(Black[bB]erry)\s?(\d+)'
     family_replacement: 'BlackBerry'
@@ -697,18 +859,15 @@ user_agent_parsers:
 
   - regex: '(QtWeb) Internet Browser/(\d+)\.(\d+)'
 
-  #- regex: '\(iPad;.+(Version)/(\d+)\.(\d+)(?:\.(\d+)|).*Safari/'
-  #  family_replacement: 'iPad'
-
   # Phantomjs, should go before Safari
   - regex: '(PhantomJS)/(\d+)\.(\d+)\.(\d+)'
 
   # WebKit Nightly
-  - regex: '(AppleWebKit)/(\d+)(?:\.(\d+)|)\+ .* Safari'
+  - regex: '(AppleWebKit)/(\d+)(?:\.(\d+)|)\+ .{0,200} Safari'
     family_replacement: 'WebKit Nightly'
 
   # Safari
-  - regex: '(Version)/(\d+)\.(\d+)(?:\.(\d+)|).*Safari/'
+  - regex: '(Version)/(\d+)\.(\d+)(?:\.(\d+)|).{0,100}Safari/'
     family_replacement: 'Safari'
   # Safari didn't provide "Version/d.d.d" prior to 3.0
   - regex: '(Safari)/\d+'
@@ -745,7 +904,7 @@ user_agent_parsers:
   # Espial
   - regex: '(Espial)/(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
 
- # Apple Mail
+  # Apple Mail
 
   # apple mail - not directly detectable, have it after Safari stuff
   - regex: '(AppleWebKit)/(\d+)\.(\d+)\.(\d+)'
@@ -757,6 +916,7 @@ user_agent_parsers:
   - regex: '(Firefox)/(\d+)\.(\d+)\.(\d+)'
   - regex: '(Firefox)/(\d+)\.(\d+)(pre|[ab]\d+[a-z]*|)'
 
+
   - regex: '([MS]?IE) (\d+)\.(\d+)'
     family_replacement: 'IE'
 
@@ -764,13 +924,45 @@ user_agent_parsers:
     family_replacement: 'Python Requests'
 
   # headless user-agents
-  - regex: '\b(Windows-Update-Agent|Microsoft-CryptoAPI|SophosUpdateManager|SophosAgent|Debian APT-HTTP|Ubuntu APT-HTTP|libcurl-agent|libwww-perl|urlgrabber|curl|PycURL|Wget|aria2|Axel|OpenBSD ftp|lftp|jupdate|insomnia)(?:[ /](\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
+  - regex: '\b(Windows-Update-Agent|WindowsPowerShell|Microsoft-CryptoAPI|SophosUpdateManager|SophosAgent|Debian APT-HTTP|Ubuntu APT-HTTP|libcurl-agent|libwww-perl|urlgrabber|curl|PycURL|Wget|wget2|aria2|Axel|OpenBSD ftp|lftp|jupdate|insomnia|fetch libfetch|akka-http|got|CloudCockpitBackend|ReactorNetty|axios|Jersey|Vert.x-WebClient|Apache-CXF|Go-CF-client|go-resty|AHC)(?:[ /](\d+)(?:\.(\d+)|)(?:\.(\d+)|)|)'
 
-  - regex: '(Java)[/ ]{0,1}\d+\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+|)'
+  # CloudFoundry
+  - regex: '^(cf)\/(\d+)\.(\d+)\.(\S+)'
+    family_replacement: 'CloudFoundry'
+
+  # SAP Leonardo
+  - regex: '^(sap-leonardo-iot-sdk-nodejs) \/ (\d+)\.(\d+)\.(\d+)'
+
+  # SAP Netweaver Application Server
+  - regex: '^(SAP NetWeaver Application Server) \(1.0;(\d{1})(\d{2})\)'
+
+  # HttpClient
+  - regex: '^(\w+-HTTPClient)\/(\d+)\.(\d+)-(\S+)'
+    family_replacement: 'HTTPClient'
+
+  # go-cli
+  - regex: '^(go-cli)\s(\d+)\.(\d+).(\S+)'
+
+  # Other Clients with the pattern <Name>/[v]<Major>.<Minor>[.<Patch>]
+  - regex: '^(Java-EurekaClient|Java-EurekaClient-Replication|HTTPClient|lua-resty-http)\/v?(\d+)\.(\d+)\.?(\d*)'
+
+  ## Clints with the pattern <Name>
+  - regex: '^(ping-service|sap xsuaa|Node-oauth|Site24x7|SAP CPI|JAEGER_SECURITY)'
+
+  # Asynchronous HTTP Client/Server for asyncio and Python (https://aiohttp.readthedocs.io/)
+  - regex: '(Python/3\.\d{1,3} aiohttp)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Python aiohttp'
+
+  - regex: '(Java)[/ ]?\d+\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+|)'
 
   # Cloud Storage Clients
   - regex: '^(Cyberduck)/(\d+)\.(\d+)\.(\d+)(?:\.\d+|)'
   - regex: '^(S3 Browser) (\d+)-(\d+)-(\d+)(?:\s*http://s3browser\.com|)'
+  - regex: '(S3Gof3r)'
+  # IBM COS (Cloud Object Storage) API
+  - regex: '\b(ibm-cos-sdk-(?:core|java|js|python))/(\d+)\.(\d+)(?:\.(\d+)|)'
+  # rusoto - Rusoto - AWS SDK for Rust - https://github.com/rusoto/rusoto
+  - regex: '^(rusoto)/(\d+)\.(\d+)\.(\d+)'
   # rclone - rsync for cloud storage - https://rclone.org/
   - regex: '^(rclone)/v(\d+)\.(\d+)'
 
@@ -783,6 +975,10 @@ user_agent_parsers:
 
   # Box Drive and Box Sync https://www.box.com/resources/downloads
   - regex: '^(Box(?: Sync)?)/(\d+)\.(\d+)\.(\d+)'
+
+  # ViaFree streaming app https://www.viafree.{dk|se|no}
+  - regex: '^(ViaFree|Viafree)-(?:tvOS-)?[A-Z]{2}/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'ViaFree'
 
 os_parsers:
   ##########
@@ -799,7 +995,7 @@ os_parsers:
   # Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11
   # Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40HX751; PKG1.902EUA; 2012;);; en) Presto/2.10.250 Version/11.60
   # Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00
-  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(; (Sony);.*;.*; ([0-9]{4});\)'
+  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(; (Sony);.{0,200};.{0,200}; ([0-9]{4});\)'
 
 
   # LG is consistent too, but we need to add manually the year model
@@ -819,9 +1015,9 @@ os_parsers:
     os_replacement: 'Samsung'
     os_v1_replacement: '2011'
   # manage the two models of 2013
-  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.*FXPDEUC'
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.{0,200}FXPDEUC'
     os_v2_replacement: 'UE40F7000'
-  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.*MST12DEUC'
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.{0,200}MST12DEUC'
     os_v2_replacement: 'UE32F4500'
   # generic Samsung (works starting in 2012)
   #- regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});'
@@ -829,22 +1025,26 @@ os_parsers:
   # Philips : not found any other way than a manual mapping
   # Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.1.3 PHILIPSTV/1.1.1; en) Presto/2.10.250 Version/11.60
   # Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70
-  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/4'
+  - regex: 'HbbTV/1\.1\.1 \(; (Philips);.{0,200}NETTV/4'
     os_v1_replacement: '2013'
-  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/3'
+  - regex: 'HbbTV/1\.1\.1 \(; (Philips);.{0,200}NETTV/3'
     os_v1_replacement: '2012'
-  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/2'
+  - regex: 'HbbTV/1\.1\.1 \(; (Philips);.{0,200}NETTV/2'
     os_v1_replacement: '2011'
 
   # the HbbTV emulator developers use HbbTV/1.1.1 (;;;;;) firetv-firefox-plugin 1.1.20
-  - regex: 'HbbTV/\d+\.\d+\.\d+.*(firetv)-firefox-plugin (\d+).(\d+).(\d+)'
+  - regex: 'HbbTV/\d+\.\d+\.\d+.{0,100}(firetv)-firefox-plugin (\d+).(\d+).(\d+)'
     os_replacement: 'FireHbbTV'
 
   # generic HbbTV, hoping to catch manufacturer name (always after 2nd comma) and the first string that looks like a 2011-2019 year
-  - regex: 'HbbTV/\d+\.\d+\.\d+ \(.*; ?([a-zA-Z]+) ?;.*(201[1-9]).*\)'
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(.{0,30}; ?([a-zA-Z]+) ?;.{0,30}(201[1-9]).{0,30}\)'
+
+  # aspiegel.com spider (owned by Huawei)
+  - regex: 'AspiegelBot'
+    os_replacement: 'Other'
 
   ##########
-  # @note: Windows Phone needs to come before Windows NT 6.1 *and* before Android to catch cases such as:
+  # @note: Windows Phone needs to come before Windows NT 6.1 {0,2}and* before Android to catch cases such as:
   # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920)...
   # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; ANZ821)...
   # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; Orange)...
@@ -853,9 +1053,15 @@ os_parsers:
 
   - regex: '(Windows Phone) (?:OS[ /])?(\d+)\.(\d+)'
 
-  # Again a MS-special one: iPhone.*Outlook-iOS-Android/x.x is erroneously detected as Android
-  - regex: '(CPU[ +]OS|iPhone[ +]OS|CPU[ +]iPhone)[ +]+(\d+)[_\.](\d+)(?:[_\.](\d+)|).*Outlook-iOS-Android'
+  # Again a MS-special one: iPhone.{0,200}Outlook-iOS-Android/x.x is erroneously detected as Android
+  - regex: '(CPU[ +]OS|iPhone[ +]OS|CPU[ +]iPhone)[ +]+(\d+)[_\.](\d+)(?:[_\.](\d+)|).{0,100}Outlook-iOS-Android'
     os_replacement: 'iOS'
+
+  # Special case for old ArcGIS Mobile products
+  - regex: 'ArcGIS\.?(iOS|Android)-\d+\.\d+(?:\.\d+|)(?:[^\/]{1,50}|)\/(\d+)(?:\.(\d+)(?:\.(\d+)|)|)'
+
+  # Special case for new ArcGIS Mobile products
+  - regex: 'ArcGISRuntime-(?:Android|iOS)\/\d+\.\d+(?:\.\d+|) \((Android|iOS) (\d+)(?:\.(\d+)(?:\.(\d+)|)|);'
 
   ##########
   # Android
@@ -882,15 +1088,18 @@ os_parsers:
   - regex: '(Android) Honeycomb'
     os_v1_replacement: '3'
 
+  # Android 9; Android 10;
+  - regex: '(Android) (\d+);'
+
   # UCWEB
-  - regex: '^UCWEB.*; (Adr) (\d+)\.(\d+)(?:[.\-]([a-z0-9]+)|);'
+  - regex: '^UCWEB.{0,200}; (Adr) (\d+)\.(\d+)(?:[.\-]([a-z0-9]{1,100})|);'
     os_replacement: 'Android'
-  - regex: '^UCWEB.*; (iPad|iPh|iPd) OS (\d+)_(\d+)(?:_(\d+)|);'
+  - regex: '^UCWEB.{0,200}; (iPad|iPh|iPd) OS (\d+)_(\d+)(?:_(\d+)|);'
     os_replacement: 'iOS'
-  - regex: '^UCWEB.*; (wds) (\d+)\.(\d+)(?:\.(\d+)|);'
+  - regex: '^UCWEB.{0,200}; (wds) (\d+)\.(\d+)(?:\.(\d+)|);'
     os_replacement: 'Windows Phone'
   # JUC
-  - regex: '^(JUC).*; ?U; ?(?:Android|)(\d+)\.(\d+)(?:[\.\-]([a-z0-9]+)|)'
+  - regex: '^(JUC).{0,200}; ?U; ?(?:Android|)(\d+)\.(\d+)(?:[\.\-]([a-z0-9]{1,100})|)'
     os_replacement: 'Android'
 
   # Salesforce
@@ -908,7 +1117,7 @@ os_parsers:
   # properly identify as Chrome OS
   #
   # ex: Mozilla/5.0 (X11; Windows aarch64 10718.88.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.118 Safari/537.36 CitrixChromeApp
-  - regex: '(x86_64|aarch64)\ (\d+)\.(\d+)\.(\d+).*Chrome.*(?:CitrixChromeApp)$'
+  - regex: '(x86_64|aarch64)\ (\d+)\.(\d+)\.(\d+).{0,100}Chrome.{0,100}(?:CitrixChromeApp)$'
     os_replacement: 'Chrome OS'
 
   ##########
@@ -929,15 +1138,19 @@ os_parsers:
   - regex: '(Windows ?Mobile)'
     os_replacement: 'Windows Mobile'
 
+  - regex: '(Windows 10)'
+    os_replacement: 'Windows'
+    os_v1_replacement: '10'
+
   - regex: '(Windows (?:NT 5\.2|NT 5\.1))'
     os_replacement: 'Windows'
     os_v1_replacement: 'XP'
 
-  - regex: '(Windows NT 6\.1)'
+  - regex: '(Win(?:dows NT |32NT\/)6\.1)'
     os_replacement: 'Windows'
     os_v1_replacement: '7'
 
-  - regex: '(Windows NT 6\.0)'
+  - regex: '(Win(?:dows NT |32NT\/)6\.0)'
     os_replacement: 'Windows'
     os_v1_replacement: 'Vista'
 
@@ -945,13 +1158,11 @@ os_parsers:
     os_replacement: 'Windows'
     os_v1_replacement: 'ME'
 
-  - regex: '(Windows 98|Windows XP|Windows ME|Windows 95|Windows CE|Windows 7|Windows NT 4\.0|Windows Vista|Windows 2000|Windows 3.1)'
-
   - regex: '(Windows NT 6\.2; ARM;)'
     os_replacement: 'Windows'
     os_v1_replacement: 'RT'
 
-  - regex: '(Windows NT 6\.2)'
+  - regex: '(Win(?:dows NT |32NT\/)6\.2)'
     os_replacement: 'Windows'
     os_v1_replacement: '8'
 
@@ -960,20 +1171,16 @@ os_parsers:
     os_v1_replacement: 'RT 8'
     os_v2_replacement: '1'
 
-  - regex: '(Windows NT 6\.3)'
+  - regex: '(Win(?:dows NT |32NT\/)6\.3)'
     os_replacement: 'Windows'
     os_v1_replacement: '8'
     os_v2_replacement: '1'
 
-  - regex: '(Windows NT 6\.4)'
+  - regex: '(Win(?:dows NT |32NT\/)6\.4)'
     os_replacement: 'Windows'
     os_v1_replacement: '10'
 
   - regex: '(Windows NT 10\.0)'
-    os_replacement: 'Windows'
-    os_v1_replacement: '10'
-
-  - regex: '(Windows 10)'
     os_replacement: 'Windows'
     os_v1_replacement: '10'
 
@@ -989,7 +1196,7 @@ os_parsers:
     os_replacement: 'Windows'
     os_v1_replacement: 'CE'
 
-  - regex: 'Win ?(95|98|3.1|NT|ME|2000)'
+  - regex: 'Win(?:dows)? ?(95|98|3.1|NT|ME|2000|XP|Vista|7|CE)'
     os_replacement: 'Windows'
     os_v1_replacement: '$1'
 
@@ -1002,7 +1209,7 @@ os_parsers:
     os_v1_replacement: '95'
 
   # Box apps (Drive, Sync, Notes) on Windows https://www.box.com/resources/downloads
-  - regex: '^Box.*Windows/([\d.]+);'
+  - regex: '^Box.{0,200}Windows/([\d.]+);'
     os_replacement: 'Windows'
     os_v1_replacement: '$1'
 
@@ -1019,33 +1226,33 @@ os_parsers:
   ##########
   - regex: '((?:Mac[ +]?|; )OS[ +]X)[\s+/](?:(\d+)[_.](\d+)(?:[_.](\d+)|)|Mach-O)'
     os_replacement: 'Mac OS X'
-  - regex: '\w+\s+Mac OS X\s+\w+\s+(\d+).(\d+).(\d+).*'
+  - regex: 'Mac OS X\s.{1,50}\s(\d+).(\d+).(\d+)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '$1'
     os_v2_replacement: '$2'
     os_v3_replacement: '$3'
   # Leopard
-  - regex: ' (Dar)(win)/(9).(\d+).*\((?:i386|x86_64|Power Macintosh)\)'
+  - regex: ' (Dar)(win)/(9).(\d+).{0,100}\((?:i386|x86_64|Power Macintosh)\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '5'
   # Snow Leopard
-  - regex: ' (Dar)(win)/(10).(\d+).*\((?:i386|x86_64)\)'
+  - regex: ' (Dar)(win)/(10).(\d+).{0,100}\((?:i386|x86_64)\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '6'
   # Lion
-  - regex: ' (Dar)(win)/(11).(\d+).*\((?:i386|x86_64)\)'
+  - regex: ' (Dar)(win)/(11).(\d+).{0,100}\((?:i386|x86_64)\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '7'
   # Mountain Lion
-  - regex: ' (Dar)(win)/(12).(\d+).*\((?:i386|x86_64)\)'
+  - regex: ' (Dar)(win)/(12).(\d+).{0,100}\((?:i386|x86_64)\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '8'
   # Mavericks
-  - regex: ' (Dar)(win)/(13).(\d+).*\((?:i386|x86_64)\)'
+  - regex: ' (Dar)(win)/(13).(\d+).{0,100}\((?:i386|x86_64)\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '9'
@@ -1062,7 +1269,7 @@ os_parsers:
   - regex: '(?:PPC|Intel) (Mac OS X)'
 
   # Box Drive and Box Sync on Mac OS X use OSX version numbers, not Darwin
-  - regex: '^Box.*;(Darwin)/(10)\.(1\d)(?:\.(\d+)|)'
+  - regex: '^Box.{0,200};(Darwin)/(10)\.(1\d)(?:\.(\d+)|)'
     os_replacement: 'Mac OS X'
 
   ##########
@@ -1073,7 +1280,7 @@ os_parsers:
   - regex: '(Apple\s?TV)(?:/(\d+)\.(\d+)|)'
     os_replacement: 'ATV OS X'
 
-  - regex: '(CPU[ +]OS|iPhone[ +]OS|CPU[ +]iPhone|CPU IPhone OS)[ +]+(\d+)[_\.](\d+)(?:[_\.](\d+)|)'
+  - regex: '(CPU[ +]OS|iPhone[ +]OS|CPU[ +]iPhone|CPU IPhone OS|CPU iPad OS)[ +]+(\d+)[_\.](\d+)(?:[_\.](\d+)|)'
     os_replacement: 'iOS'
 
   # remaining cases are mostly only opera uas, so catch opera as to not catch iphone spoofs
@@ -1081,15 +1288,15 @@ os_parsers:
     os_replacement: 'iOS'
 
   # few more stragglers
-  - regex: '(iPhone|iPad|iPod).*Mac OS X.*Version/(\d+)\.(\d+)'
+  - regex: '(iPhone|iPad|iPod).{0,100}Mac OS X.{0,100}Version/(\d+)\.(\d+)'
     os_replacement: 'iOS'
 
   # CFNetwork/Darwin - The specific CFNetwork or Darwin version determines
   # whether the os maps to Mac OS, or iOS, or just Darwin.
   # See: http://user-agents.me/cfnetwork-version-list
-  - regex: '(CFNetwork)/(5)48\.0\.3.* Darwin/11\.0\.0'
+  - regex: '(CFNetwork)/(5)48\.0\.3.{0,100} Darwin/11\.0\.0'
     os_replacement: 'iOS'
-  - regex: '(CFNetwork)/(5)48\.(0)\.4.* Darwin/(1)1\.0\.0'
+  - regex: '(CFNetwork)/(5)48\.(0)\.4.{0,100} Darwin/(1)1\.0\.0'
     os_replacement: 'iOS'
   - regex: '(CFNetwork)/(5)48\.(1)\.4'
     os_replacement: 'iOS'
@@ -1124,17 +1331,17 @@ os_parsers:
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '11'
-  - regex: 'CFNetwork/7.* Darwin/15\.4\.\d+'
+  - regex: 'CFNetwork/7.{0,100} Darwin/15\.4\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '9'
     os_v2_replacement: '3'
     os_v3_replacement: '1'
-  - regex: 'CFNetwork/7.* Darwin/15\.5\.\d+'
+  - regex: 'CFNetwork/7.{0,100} Darwin/15\.5\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '9'
     os_v2_replacement: '3'
     os_v3_replacement: '2'
-  - regex: 'CFNetwork/7.* Darwin/15\.6\.\d+'
+  - regex: 'CFNetwork/7.{0,100} Darwin/15\.6\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '9'
     os_v2_replacement: '3'
@@ -1155,15 +1362,15 @@ os_parsers:
   # CFNetwork macOS Apps (must be before CFNetwork iOS Apps
   # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
   ##########
-  - regex: 'CFNetwork/.* Darwin/17\.\d+.*\(x86_64\)'
+  - regex: 'CFNetwork/.{0,100} Darwin/17\.\d+.{0,100}\(x86_64\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '13'
-  - regex: 'CFNetwork/.* Darwin/16\.\d+.*\(x86_64\)'
+  - regex: 'CFNetwork/.{0,100} Darwin/16\.\d+.{0,100}\(x86_64\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '12'
-  - regex: 'CFNetwork/8.* Darwin/15\.\d+.*\(x86_64\)'
+  - regex: 'CFNetwork/8.{0,100} Darwin/15\.\d+.{0,100}\(x86_64\)'
     os_replacement: 'Mac OS X'
     os_v1_replacement: '10'
     os_v2_replacement: '11'
@@ -1171,87 +1378,146 @@ os_parsers:
   # CFNetwork iOS Apps
   # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
   ##########
-  - regex: 'CFNetwork/.* Darwin/(9)\.\d+'
+  - regex: 'CFNetwork/.{0,100} Darwin/(9)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '1'
-  - regex: 'CFNetwork/.* Darwin/(10)\.\d+'
+  - regex: 'CFNetwork/.{0,100} Darwin/(10)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '4'
-  - regex: 'CFNetwork/.* Darwin/(11)\.\d+'
+  - regex: 'CFNetwork/.{0,100} Darwin/(11)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '5'
-  - regex: 'CFNetwork/.* Darwin/(13)\.\d+'
+  - regex: 'CFNetwork/.{0,100} Darwin/(13)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '6'
-  - regex: 'CFNetwork/6.* Darwin/(14)\.\d+'
+  - regex: 'CFNetwork/6.{0,100} Darwin/(14)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '7'
-  - regex: 'CFNetwork/7.* Darwin/(14)\.\d+'
+  - regex: 'CFNetwork/7.{0,100} Darwin/(14)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '8'
     os_v2_replacement: '0'
-  - regex: 'CFNetwork/7.* Darwin/(15)\.\d+'
+  - regex: 'CFNetwork/7.{0,100} Darwin/(15)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '9'
     os_v2_replacement: '0'
-  - regex: 'CFNetwork/8.* Darwin/16\.5\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/16\.5\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '10'
     os_v2_replacement: '3'
-  - regex: 'CFNetwork/8.* Darwin/16\.6\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/16\.6\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '10'
     os_v2_replacement: '3'
     os_v3_replacement: '2'
-  - regex: 'CFNetwork/8.* Darwin/16\.7\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/16\.7\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '10'
     os_v2_replacement: '3'
     os_v3_replacement: '3'
-  - regex: 'CFNetwork/8.* Darwin/(16)\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/(16)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '10'
-  - regex: 'CFNetwork/8.* Darwin/17\.0\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/17\.0\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
     os_v2_replacement: '0'
-  - regex: 'CFNetwork/8.* Darwin/17\.2\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/17\.2\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
     os_v2_replacement: '1'
-  - regex: 'CFNetwork/8.* Darwin/17\.3\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/17\.3\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
     os_v2_replacement: '2'
-  - regex: 'CFNetwork/8.* Darwin/17\.4\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/17\.4\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
     os_v2_replacement: '2'
     os_v3_replacement: '6'
-  - regex: 'CFNetwork/8.* Darwin/17\.5\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/17\.5\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
     os_v2_replacement: '3'
-  - regex: 'CFNetwork/9.* Darwin/17\.6\.\d+'
+  - regex: 'CFNetwork/9.{0,100} Darwin/17\.6\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
     os_v2_replacement: '4'
-  - regex: 'CFNetwork/9.* Darwin/17\.7\.\d+'
+  - regex: 'CFNetwork/9.{0,100} Darwin/17\.7\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
     os_v2_replacement: '4'
     os_v3_replacement: '1'
-  - regex: 'CFNetwork/8.* Darwin/(17)\.\d+'
+  - regex: 'CFNetwork/8.{0,100} Darwin/(17)\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '11'
-  - regex: 'CFNetwork/9.* Darwin/18\.0\.\d+'
+  - regex: 'CFNetwork/9.{0,100} Darwin/18\.0\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '12'
     os_v2_replacement: '0'
-  - regex: 'CFNetwork/9.* Darwin/(18)\.\d+'
+  - regex: 'CFNetwork/9.{0,100} Darwin/18\.2\.\d+'
     os_replacement: 'iOS'
     os_v1_replacement: '12'
-  - regex: 'CFNetwork/.* Darwin/'
+    os_v2_replacement: '1'
+  - regex: 'CFNetwork/9.{0,100} Darwin/18\.5\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '12'
+    os_v2_replacement: '2'
+  - regex: 'CFNetwork/9.{0,100} Darwin/18\.6\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '12'
+    os_v2_replacement: '3'
+  - regex: 'CFNetwork/9.{0,100} Darwin/18\.7\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '12'
+    os_v2_replacement: '4'
+  - regex: 'CFNetwork/9.{0,100} Darwin/(18)\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '12'
+  - regex: 'CFNetwork/11.{0,100} Darwin/19\.2\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '13'
+    os_v2_replacement: '3'
+  - regex: 'CFNetwork/11.{0,100} Darwin/19\.3\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '13'
+    os_v2_replacement: '3'
+    os_v3_replacement: '1'
+  - regex: 'CFNetwork/11.{0,100} Darwin/19\.4\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '13'
+    os_v2_replacement: '4'
+  - regex: 'CFNetwork/11.{0,100} Darwin/19\.5\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '13'
+    os_v2_replacement: '5'
+  - regex: 'CFNetwork/11.{0,100} Darwin/19\.6\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '13'
+    os_v2_replacement: '6'
+  - regex: 'CFNetwork/1[01].{0,100} Darwin/19\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '13'
+  - regex: 'CFNetwork/12.{0,100} Darwin/20\.1\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '14'
+    os_v2_replacement: '2'
+  - regex: 'CFNetwork/12.{0,100} Darwin/20\.2\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '14'
+    os_v2_replacement: '3'
+  - regex: 'CFNetwork/12.{0,100} Darwin/20\.3\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '14'
+    os_v2_replacement: '4'
+  - regex: 'CFNetwork/12.{0,100} Darwin/20\.4\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '14'
+    os_v2_replacement: '5'
+  - regex: 'CFNetwork/.{0,100} Darwin/(20)\.\d+'
+    os_replacement: 'iOS'
+    os_v1_replacement: '14'
+  - regex: 'CFNetwork/.{0,100} Darwin/'
     os_replacement: 'iOS'
 
   # iOS Apps
@@ -1259,15 +1525,27 @@ os_parsers:
     os_replacement: 'iOS'
   - regex: '\((iOS);'
 
+  ##########
+  # Apple Watch
+  ##########
+  - regex: '(watchOS)/(\d+)\.(\d+)(?:\.(\d+)|)'
+    os_replacement: 'WatchOS'
+
   ##########################
   # Outlook on iOS >= 2.62.0
   ##########################
   - regex: 'Outlook-(iOS)/\d+\.\d+\.prod\.iphone'
 
+  ##########################
+  # iOS devices, the same regex matches mobile safari webviews
+  ##########################
+  - regex: '(iPod|iPhone|iPad)'
+    os_replacement: 'iOS'
+
   ##########
   # Apple TV
   ##########
-  - regex: '(tvOS)/(\d+).(\d+)'
+  - regex: '(tvOS)[/ ](\d+)\.(\d+)(?:\.(\d+)|)'
     os_replacement: 'tvOS'
 
   ##########
@@ -1293,9 +1571,9 @@ os_parsers:
   ##########
   - regex: '(Symbian[Oo][Ss])[/ ](\d+)\.(\d+)'
     os_replacement: 'Symbian OS'
-  - regex: '(Symbian/3).+NokiaBrowser/7\.3'
+  - regex: '(Symbian/3).{1,200}NokiaBrowser/7\.3'
     os_replacement: 'Symbian^3 Anna'
-  - regex: '(Symbian/3).+NokiaBrowser/7\.4'
+  - regex: '(Symbian/3).{1,200}NokiaBrowser/7\.4'
     os_replacement: 'Symbian^3 Belle'
   - regex: '(Symbian/3)'
     os_replacement: 'Symbian^3'
@@ -1312,11 +1590,11 @@ os_parsers:
   ##########
   # BlackBerry devices
   ##########
-  - regex: '(BB10);.+Version/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(BB10);.{1,200}Version/(\d+)\.(\d+)\.(\d+)'
     os_replacement: 'BlackBerry OS'
   - regex: '(Black[Bb]erry)[0-9a-z]+/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|)'
     os_replacement: 'BlackBerry OS'
-  - regex: '(Black[Bb]erry).+Version/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|)'
+  - regex: '(Black[Bb]erry).{1,200}Version/(\d+)\.(\d+)\.(\d+)(?:\.(\d+)|)'
     os_replacement: 'BlackBerry OS'
   - regex: '(RIM Tablet OS) (\d+)\.(\d+)\.(\d+)'
     os_replacement: 'BlackBerry Tablet OS'
@@ -1326,46 +1604,52 @@ os_parsers:
     os_replacement: 'BlackBerry OS'
 
   ##########
+  # KaiOS
+  ##########
+  - regex: '(K[Aa][Ii]OS)\/(\d+)\.(\d+)(?:\.(\d+)|)'
+    os_replacement: 'KaiOS'
+
+  ##########
   # Firefox OS
   ##########
-  - regex: '\((?:Mobile|Tablet);.+Gecko/18.0 Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Gecko/18.0 Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
     os_v1_replacement: '1'
     os_v2_replacement: '0'
     os_v3_replacement: '1'
 
-  - regex: '\((?:Mobile|Tablet);.+Gecko/18.1 Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Gecko/18.1 Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
     os_v1_replacement: '1'
     os_v2_replacement: '1'
 
-  - regex: '\((?:Mobile|Tablet);.+Gecko/26.0 Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Gecko/26.0 Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
     os_v1_replacement: '1'
     os_v2_replacement: '2'
 
-  - regex: '\((?:Mobile|Tablet);.+Gecko/28.0 Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Gecko/28.0 Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
     os_v1_replacement: '1'
     os_v2_replacement: '3'
 
-  - regex: '\((?:Mobile|Tablet);.+Gecko/30.0 Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Gecko/30.0 Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
     os_v1_replacement: '1'
     os_v2_replacement: '4'
 
-  - regex: '\((?:Mobile|Tablet);.+Gecko/32.0 Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Gecko/32.0 Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
     os_v1_replacement: '2'
     os_v2_replacement: '0'
 
-  - regex: '\((?:Mobile|Tablet);.+Gecko/34.0 Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Gecko/34.0 Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
     os_v1_replacement: '2'
     os_v2_replacement: '1'
 
   # Firefox OS Generic
-  - regex: '\((?:Mobile|Tablet);.+Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.{1,200}Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
 
 
@@ -1404,10 +1688,10 @@ os_parsers:
   # Generic patterns
   # since the majority of os cases are very specific, these go last
   ##########
-  - regex: '(Fedora|Red Hat|PCLinuxOS|Puppy|Ubuntu|Kindle|Bada|Lubuntu|BackTrack|Slackware|(?:Free|Open|Net|\b)BSD)[/ ](\d+)\.(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
+  - regex: '(Fedora|Red Hat|PCLinuxOS|Puppy|Ubuntu|Kindle|Bada|Sailfish|Lubuntu|BackTrack|Slackware|(?:Free|Open|Net|\b)BSD)[/ ](\d+)\.(\d+)(?:\.(\d+)|)(?:\.(\d+)|)'
 
   # Gentoo Linux + Kernel Version
-  - regex: '(Linux)[ /](\d+)\.(\d+)(?:\.(\d+)|).*gentoo'
+  - regex: '(Linux)[ /](\d+)\.(\d+)(?:\.(\d+)|).{0,100}gentoo'
     os_replacement: 'Gentoo'
 
   # Opera Mini Bada
@@ -1427,6 +1711,8 @@ os_parsers:
     os_replacement: 'Red Hat'
   - regex: '\((freebsd)(\d+)\.(\d+)\)'
     os_replacement: 'FreeBSD'
+  - regex: 'linux'
+    os_replacement: 'Linux'
 
   # Roku Digital-Video-Players https://www.roku.com/
   - regex: '^(Roku)/DVP-(\d+)\.(\d+)'
@@ -1437,22 +1723,42 @@ device_parsers:
   # Mobile Spiders
   # Catch the mobile crawler before checking for iPhones / Androids.
   #########
-  - regex: '(?:(?:iPhone|Windows CE|Windows Phone|Android).*(?:(?:Bot|Yeti)-Mobile|YRSpider|BingPreview|bots?/\d|(?:bot|spider)\.html)|AdsBot-Google-Mobile.*iPhone)'
+  - regex: '^.{0,100}?(?:(?:iPhone|Windows CE|Windows Phone|Android).{0,300}(?:(?:Bot|Yeti)-Mobile|YRSpider|BingPreview|bots?/\d|(?:bot|spider)\.html)|AdsBot-Google-Mobile.{0,200}iPhone)'
     regex_flag: 'i'
     device_replacement: 'Spider'
     brand_replacement: 'Spider'
     model_replacement: 'Smartphone'
-  - regex: '(?:DoCoMo|\bMOT\b|\bLG\b|Nokia|Samsung|SonyEricsson).*(?:(?:Bot|Yeti)-Mobile|bots?/\d|(?:bot|crawler)\.html|(?:jump|google|Wukong)bot|ichiro/mobile|/spider|YahooSeeker)'
+  - regex: '^.{0,100}?(?:DoCoMo|\bMOT\b|\bLG\b|Nokia|Samsung|SonyEricsson).{0,200}(?:(?:Bot|Yeti)-Mobile|bots?/\d|(?:bot|crawler)\.html|(?:jump|google|Wukong)bot|ichiro/mobile|/spider|YahooSeeker)'
     regex_flag: 'i'
     device_replacement: 'Spider'
     brand_replacement: 'Spider'
     model_replacement: 'Feature Phone'
 
+  # PTST / WebPageTest.org crawlers
+  - regex: ' PTST/\d+(?:\.\d+|)$'
+    device_replacement: 'Spider'
+    brand_replacement: 'Spider'
+
+  # Datanyze.com spider
+  - regex: 'X11; Datanyze; Linux'
+    device_replacement: 'Spider'
+    brand_replacement: 'Spider'
+
+  # aspiegel.com spider (owned by Huawei)
+  - regex: 'Mozilla.{1,100}Mobile.{1,100}AspiegelBot'
+    device_replacement: 'Spider'
+    brand_replacement: 'Spider'
+    model_replacement: 'Smartphone'
+  - regex: 'Mozilla.{0,200}AspiegelBot'
+    device_replacement: 'Spider'
+    brand_replacement: 'Spider'
+    model_replacement: 'Desktop'
+
   #########
   # WebBrowser for SmartWatch
   # @ref: https://play.google.com/store/apps/details?id=se.vaggan.webbrowser&hl=en
   #########
-  - regex: '\bSmartWatch *\( *([^;]+) *; *([^;]+) *;'
+  - regex: '\bSmartWatch {0,2}\( {0,2}([^;]{1,200}) {0,2}; {0,2}([^;]{1,200}) {0,2};'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -1464,16 +1770,16 @@ device_parsers:
   ######################################################################
 
   # Android Application
-  - regex: 'Android Application[^\-]+ - (Sony) ?(Ericsson|) (.+) \w+ - '
+  - regex: 'Android Application[^\-]{1,300} - (Sony) ?(Ericsson|) (.{1,200}) \w{1,20} - '
     device_replacement: '$1 $2'
     brand_replacement: '$1$2'
     model_replacement: '$3'
-  - regex: 'Android Application[^\-]+ - (?:HTC|HUAWEI|LGE|LENOVO|MEDION|TCT) (HTC|HUAWEI|LG|LENOVO|MEDION|ALCATEL)[ _\-](.+) \w+ - '
+  - regex: 'Android Application[^\-]{1,300} - (?:HTC|HUAWEI|LGE|LENOVO|MEDION|TCT) (HTC|HUAWEI|LG|LENOVO|MEDION|ALCATEL)[ _\-](.{1,200}) \w{1,20} - '
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
-  - regex: 'Android Application[^\-]+ - ([^ ]+) (.+) \w+ - '
+  - regex: 'Android Application[^\-]{1,300} - ([^ ]+) (.{1,200}) \w{1,20} - '
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -1482,11 +1788,11 @@ device_parsers:
   # 3Q
   # @ref: http://www.3q-int.com/
   #########
-  - regex: '; *([BLRQ]C\d{4}[A-Z]+) +Build/'
+  - regex: '; {0,2}([BLRQ]C\d{4}[A-Z]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '3Q $1'
     brand_replacement: '3Q'
     model_replacement: '$1'
-  - regex: '; *(?:3Q_)([^;/]+) +Build'
+  - regex: '; {0,2}(?:3Q_)([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '3Q $1'
     brand_replacement: '3Q'
     model_replacement: '$1'
@@ -1495,19 +1801,19 @@ device_parsers:
   # Acer
   # @ref: http://us.acer.com/ac/en/US/content/group/tablets
   #########
-  - regex: 'Android [34].*; *(A100|A101|A110|A200|A210|A211|A500|A501|A510|A511|A700(?: Lite| 3G|)|A701|B1-A71|A1-\d{3}|B1-\d{3}|V360|V370|W500|W500P|W501|W501P|W510|W511|W700|Slider SL101|DA22[^;/]+) Build'
+  - regex: 'Android [34].{0,200}; {0,2}(A100|A101|A110|A200|A210|A211|A500|A501|A510|A511|A700(?: Lite| 3G|)|A701|B1-A71|A1-\d{3}|B1-\d{3}|V360|V370|W500|W500P|W501|W501P|W510|W511|W700|Slider SL101|DA22[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Acer'
     model_replacement: '$1'
-  - regex: '; *Acer Iconia Tab ([^;/]+) Build'
+  - regex: '; {0,2}Acer Iconia Tab ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Acer'
     model_replacement: '$1'
-  - regex: '; *(Z1[1235]0|E320[^/]*|S500|S510|Liquid[^;/]*|Iconia A\d+) Build'
+  - regex: '; {0,2}(Z1[1235]0|E320[^/]{0,10}|S500|S510|Liquid[^;/]{0,30}|Iconia A\d+)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Acer'
     model_replacement: '$1'
-  - regex: '; *(Acer |ACER )([^;/]+) Build'
+  - regex: '; {0,2}(Acer |ACER )([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Acer'
     model_replacement: '$2'
@@ -1518,7 +1824,7 @@ device_parsers:
   # @note: VegaBean and VegaComb (names derived from jellybean, honeycomb) are
   #   custom ROM builds for Vega
   #########
-  - regex: '; *(Advent |)(Vega(?:Bean|Comb|)).* Build'
+  - regex: '; {0,2}(Advent |)(Vega(?:Bean|Comb|)).{0,200}?(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Advent'
     model_replacement: '$2'
@@ -1527,7 +1833,7 @@ device_parsers:
   # Ainol
   # @ref: http://www.ainol.com/plugin.php?identifier=ainol&module=product
   #########
-  - regex: '; *(Ainol |)((?:NOVO|[Nn]ovo)[^;/]+) Build'
+  - regex: '; {0,2}(Ainol |)((?:NOVO|[Nn]ovo)[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Ainol'
     model_replacement: '$2'
@@ -1536,12 +1842,12 @@ device_parsers:
   # Airis
   # @ref: http://airis.es/Tienda/Default.aspx?idG=001
   #########
-  - regex: '; *AIRIS[ _\-]?([^/;\)]+) *(?:;|\)|Build)'
+  - regex: '; {0,2}AIRIS[ _\-]?([^/;\)]+) {0,2}(?:;|\)|Build)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Airis'
     model_replacement: '$1'
-  - regex: '; *(OnePAD[^;/]+) Build'
+  - regex: '; {0,2}(OnePAD[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Airis'
@@ -1551,7 +1857,7 @@ device_parsers:
   # Airpad
   # @ref: ??
   #########
-  - regex: '; *Airpad[ \-]([^;/]+) Build'
+  - regex: '; {0,2}Airpad[ \-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Airpad $1'
     brand_replacement: 'Airpad'
     model_replacement: '$1'
@@ -1560,29 +1866,29 @@ device_parsers:
   # Alcatel - TCT
   # @ref: http://www.alcatelonetouch.com/global-en/products/smartphones.html
   #########
-  - regex: '; *(one ?touch) (EVO7|T10|T20) Build'
+  - regex: '; {0,2}(one ?touch) (EVO7|T10|T20)(?: Build|\) AppleWebKit)'
     device_replacement: 'Alcatel One Touch $2'
     brand_replacement: 'Alcatel'
     model_replacement: 'One Touch $2'
-  - regex: '; *(?:alcatel[ _]|)(?:(?:one[ _]?touch[ _])|ot[ \-])([^;/]+);? Build'
+  - regex: '; {0,2}(?:alcatel[ _]|)(?:(?:one[ _]?touch[ _])|ot[ \-])([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Alcatel One Touch $1'
     brand_replacement: 'Alcatel'
     model_replacement: 'One Touch $1'
-  - regex: '; *(TCL)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(TCL)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
   # operator specific models
-  - regex: '; *(Vodafone Smart II|Optimus_Madrid) Build'
+  - regex: '; {0,2}(Vodafone Smart II|Optimus_Madrid)(?: Build|\) AppleWebKit)'
     device_replacement: 'Alcatel $1'
     brand_replacement: 'Alcatel'
     model_replacement: '$1'
-  - regex: '; *BASE_Lutea_3 Build'
+  - regex: '; {0,2}BASE_Lutea_3(?: Build|\) AppleWebKit)'
     device_replacement: 'Alcatel One Touch 998'
     brand_replacement: 'Alcatel'
     model_replacement: 'One Touch 998'
-  - regex: '; *BASE_Varia Build'
+  - regex: '; {0,2}BASE_Varia(?: Build|\) AppleWebKit)'
     device_replacement: 'Alcatel One Touch 918D'
     brand_replacement: 'Alcatel'
     model_replacement: 'One Touch 918D'
@@ -1591,7 +1897,7 @@ device_parsers:
   # Allfine
   # @ref: http://www.myallfine.com/Products.asp
   #########
-  - regex: '; *((?:FINE|Fine)\d[^;/]+) Build'
+  - regex: '; {0,2}((?:FINE|Fine)\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Allfine'
     model_replacement: '$1'
@@ -1600,15 +1906,15 @@ device_parsers:
   # Allview
   # @ref: http://www.allview.ro/produse/droseries/lista-tablete-pc/
   #########
-  - regex: '; *(ALLVIEW[ _]?|Allview[ _]?)((?:Speed|SPEED).*) Build/'
+  - regex: '; {0,2}(ALLVIEW[ _]?|Allview[ _]?)((?:Speed|SPEED).{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Allview'
     model_replacement: '$2'
-  - regex: '; *(ALLVIEW[ _]?|Allview[ _]?|)(AX1_Shine|AX2_Frenzy) Build'
+  - regex: '; {0,2}(ALLVIEW[ _]?|Allview[ _]?|)(AX1_Shine|AX2_Frenzy)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Allview'
     model_replacement: '$2'
-  - regex: '; *(ALLVIEW[ _]?|Allview[ _]?)([^;/]*) Build'
+  - regex: '; {0,2}(ALLVIEW[ _]?|Allview[ _]?)([^;/]*?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Allview'
     model_replacement: '$2'
@@ -1618,11 +1924,11 @@ device_parsers:
   # @ref: http://www.allwinner.com/
   # @models: A31 (13.3"),A20,A10,
   #########
-  - regex: '; *(A13-MID) Build'
+  - regex: '; {0,2}(A13-MID)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Allwinner'
     model_replacement: '$1'
-  - regex: '; *(Allwinner)[ _\-]?([^;/]+) Build'
+  - regex: '; {0,2}(Allwinner)[ _\-]?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Allwinner'
     model_replacement: '$1'
@@ -1631,7 +1937,7 @@ device_parsers:
   # Amaway
   # @ref: http://www.amaway.cn/
   #########
-  - regex: '; *(A651|A701B?|A702|A703|A705|A706|A707|A711|A712|A713|A717|A722|A785|A801|A802|A803|A901|A902|A1002|A1003|A1006|A1007|A9701|A9703|Q710|Q80) Build'
+  - regex: '; {0,2}(A651|A701B?|A702|A703|A705|A706|A707|A711|A712|A713|A717|A722|A785|A801|A802|A803|A901|A902|A1002|A1003|A1006|A1007|A9701|A9703|Q710|Q80)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Amaway'
     model_replacement: '$1'
@@ -1640,11 +1946,11 @@ device_parsers:
   # Amoi
   # @ref: http://www.amoi.com/en/prd/prd_index.jspx
   #########
-  - regex: '; *(?:AMOI|Amoi)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(?:AMOI|Amoi)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Amoi $1'
     brand_replacement: 'Amoi'
     model_replacement: '$1'
-  - regex: '^(?:AMOI|Amoi)[ _]([^;/]+) Linux'
+  - regex: '^(?:AMOI|Amoi)[ _]([^;/]{1,100}?) Linux'
     device_replacement: 'Amoi $1'
     brand_replacement: 'Amoi'
     model_replacement: '$1'
@@ -1653,7 +1959,7 @@ device_parsers:
   # Aoc
   # @ref: http://latin.aoc.com/media_tablet
   #########
-  - regex: '; *(MW(?:0[789]|10)[^;/]+) Build'
+  - regex: '; {0,2}(MW(?:0[789]|10)[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Aoc'
     model_replacement: '$1'
@@ -1664,11 +1970,11 @@ device_parsers:
   # @ref: http://www.luckystar.com.cn/en/mobiletel.aspx?page=1
   # @note: brand owned by luckystar
   #########
-  - regex: '; *(G7|M1013|M1015G|M11[CG]?|M-?12[B]?|M15|M19[G]?|M30[ACQ]?|M31[GQ]|M32|M33[GQ]|M36|M37|M38|M701T|M710|M712B|M713|M715G|M716G|M71(?:G|GS|T|)|M72[T]?|M73[T]?|M75[GT]?|M77G|M79T|M7L|M7LN|M81|M810|M81T|M82|M92|M92KS|M92S|M717G|M721|M722G|M723|M725G|M739|M785|M791|M92SK|M93D) Build'
+  - regex: '; {0,2}(G7|M1013|M1015G|M11[CG]?|M-?12[B]?|M15|M19[G]?|M30[ACQ]?|M31[GQ]|M32|M33[GQ]|M36|M37|M38|M701T|M710|M712B|M713|M715G|M716G|M71(?:G|GS|T|)|M72[T]?|M73[T]?|M75[GT]?|M77G|M79T|M7L|M7LN|M81|M810|M81T|M82|M92|M92KS|M92S|M717G|M721|M722G|M723|M725G|M739|M785|M791|M92SK|M93D)(?: Build|\) AppleWebKit)'
     device_replacement: 'Aoson $1'
     brand_replacement: 'Aoson'
     model_replacement: '$1'
-  - regex: '; *Aoson ([^;/]+) Build'
+  - regex: '; {0,2}Aoson ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Aoson $1'
     brand_replacement: 'Aoson'
@@ -1678,7 +1984,7 @@ device_parsers:
   # Apanda
   # @ref: http://www.apanda.com.cn/
   #########
-  - regex: '; *[Aa]panda[ _\-]([^;/]+) Build'
+  - regex: '; {0,2}[Aa]panda[ _\-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Apanda $1'
     brand_replacement: 'Apanda'
     model_replacement: '$1'
@@ -1688,23 +1994,23 @@ device_parsers:
   # @ref: http://www.archos.com/de/products/tablets.html
   # @ref: http://www.archos.com/de/products/smartphones/index.html
   #########
-  - regex: '; *(?:ARCHOS|Archos) ?(GAMEPAD.*?)(?: Build|[;/\(\)\-])'
+  - regex: '; {0,2}(?:ARCHOS|Archos) ?(GAMEPAD.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Archos $1'
     brand_replacement: 'Archos'
     model_replacement: '$1'
-  - regex: 'ARCHOS; GOGI; ([^;]+);'
+  - regex: 'ARCHOS; GOGI; ([^;]{1,200});'
     device_replacement: 'Archos $1'
     brand_replacement: 'Archos'
     model_replacement: '$1'
-  - regex: '(?:ARCHOS|Archos)[ _]?(.*?)(?: Build|[;/\(\)\-]|$)'
+  - regex: '(?:ARCHOS|Archos)[ _]?(.{0,200}?)(?: Build|[;/\(\)\-]|$)'
     device_replacement: 'Archos $1'
     brand_replacement: 'Archos'
     model_replacement: '$1'
-  - regex: '; *(AN(?:7|8|9|10|13)[A-Z0-9]{1,4}) Build'
+  - regex: '; {0,2}(AN(?:7|8|9|10|13)[A-Z0-9]{1,4})(?: Build|\) AppleWebKit)'
     device_replacement: 'Archos $1'
     brand_replacement: 'Archos'
     model_replacement: '$1'
-  - regex: '; *(A28|A32|A43|A70(?:BHT|CHT|HB|S|X)|A101(?:B|C|IT)|A7EB|A7EB-WK|101G9|80G9) Build'
+  - regex: '; {0,2}(A28|A32|A43|A70(?:BHT|CHT|HB|S|X)|A101(?:B|C|IT)|A7EB|A7EB-WK|101G9|80G9)(?: Build|\) AppleWebKit)'
     device_replacement: 'Archos $1'
     brand_replacement: 'Archos'
     model_replacement: '$1'
@@ -1713,11 +2019,11 @@ device_parsers:
   # A-rival
   # @ref: http://www.a-rival.de/de/
   #########
-  - regex: '; *(PAD-FMD[^;/]+) Build'
+  - regex: '; {0,2}(PAD-FMD[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Arival'
     model_replacement: '$1'
-  - regex: '; *(BioniQ) ?([^;/]+) Build'
+  - regex: '; {0,2}(BioniQ) ?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Arival'
     model_replacement: '$1 $2'
@@ -1726,11 +2032,11 @@ device_parsers:
   # Arnova
   # @ref: http://arnovatech.com/
   #########
-  - regex: '; *(AN\d[^;/]+|ARCHM\d+) Build'
+  - regex: '; {0,2}(AN\d[^;/]{1,100}|ARCHM\d+)(?: Build|\) AppleWebKit)'
     device_replacement: 'Arnova $1'
     brand_replacement: 'Arnova'
     model_replacement: '$1'
-  - regex: '; *(?:ARNOVA|Arnova) ?([^;/]+) Build'
+  - regex: '; {0,2}(?:ARNOVA|Arnova) ?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Arnova $1'
     brand_replacement: 'Arnova'
     model_replacement: '$1'
@@ -1739,7 +2045,7 @@ device_parsers:
   # Assistant
   # @ref: http://www.assistant.ua
   #########
-  - regex: '; *(?:ASSISTANT |)(AP)-?([1789]\d{2}[A-Z]{0,2}|80104) Build'
+  - regex: '; {0,2}(?:ASSISTANT |)(AP)-?([1789]\d{2}[A-Z]{0,2}|80104)(?: Build|\) AppleWebKit)'
     device_replacement: 'Assistant $1-$2'
     brand_replacement: 'Assistant'
     model_replacement: '$1-$2'
@@ -1748,11 +2054,11 @@ device_parsers:
   # Asus
   # @ref: http://www.asus.com/uk/Tablets_Mobile/
   #########
-  - regex: '; *(ME17\d[^;/]*|ME3\d{2}[^;/]+|K00[A-Z]|Nexus 10|Nexus 7(?: 2013|)|PadFone[^;/]*|Transformer[^;/]*|TF\d{3}[^;/]*|eeepc) Build'
+  - regex: '; {0,2}(ME17\d[^;/]*|ME3\d{2}[^;/]{1,100}|K00[A-Z]|Nexus 10|Nexus 7(?: 2013|)|PadFone[^;/]*|Transformer[^;/]*|TF\d{3}[^;/]*|eeepc)(?: Build|\) AppleWebKit)'
     device_replacement: 'Asus $1'
     brand_replacement: 'Asus'
     model_replacement: '$1'
-  - regex: '; *ASUS[ _]*([^;/]+) Build'
+  - regex: '; {0,2}ASUS[ _]{0,10}([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Asus $1'
     brand_replacement: 'Asus'
     model_replacement: '$1'
@@ -1760,11 +2066,11 @@ device_parsers:
   #########
   # Garmin-Asus
   #########
-  - regex: '; *Garmin-Asus ([^;/]+) Build'
+  - regex: '; {0,2}Garmin-Asus ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Garmin-Asus $1'
     brand_replacement: 'Garmin-Asus'
     model_replacement: '$1'
-  - regex: '; *(Garminfone) Build'
+  - regex: '; {0,2}(Garminfone)(?: Build|\) AppleWebKit)'
     device_replacement: 'Garmin $1'
     brand_replacement: 'Garmin-Asus'
     model_replacement: '$1'
@@ -1773,7 +2079,7 @@ device_parsers:
   # Attab
   # @ref: http://www.theattab.com/
   #########
-  - regex: '; (@TAB-[^;/]+) Build'
+  - regex: '; (@TAB-[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Attab'
     model_replacement: '$1'
@@ -1783,7 +2089,7 @@ device_parsers:
   # @ref: ??
   # @note: Take care with Docomo T-01 Toshiba
   #########
-  - regex: '; *(T-(?:07|[^0]\d)[^;/]+) Build'
+  - regex: '; {0,2}(T-(?:07|[^0]\d)[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Audiosonic'
     model_replacement: '$1'
@@ -1792,7 +2098,7 @@ device_parsers:
   # Axioo
   # @ref: http://www.axiooworld.com/ww/index.php
   #########
-  - regex: '; *(?:Axioo[ _\-]([^;/]+)|(picopad)[ _\-]([^;/]+)) Build'
+  - regex: '; {0,2}(?:Axioo[ _\-]([^;/]{1,100}?)|(picopad)[ _\-]([^;/]{1,100}?))(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Axioo $1$2 $3'
     brand_replacement: 'Axioo'
@@ -1802,7 +2108,7 @@ device_parsers:
   # Azend
   # @ref: http://azendcorp.com/index.php/products/portable-electronics
   #########
-  - regex: '; *(V(?:100|700|800)[^;/]*) Build'
+  - regex: '; {0,2}(V(?:100|700|800)[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Azend'
     model_replacement: '$1'
@@ -1811,7 +2117,7 @@ device_parsers:
   # Bak
   # @ref: http://www.bakinternational.com/produtos.php?cat=80
   #########
-  - regex: '; *(IBAK\-[^;/]*) Build'
+  - regex: '; {0,2}(IBAK\-[^;/]*)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Bak'
@@ -1822,7 +2128,7 @@ device_parsers:
   # @ref: http://www.bedove.com/product.html
   # @models: HY6501|HY5001|X12|X21|I5
   #########
-  - regex: '; *(HY5001|HY6501|X12|X21|I5) Build'
+  - regex: '; {0,2}(HY5001|HY6501|X12|X21|I5)(?: Build|\) AppleWebKit)'
     device_replacement: 'Bedove $1'
     brand_replacement: 'Bedove'
     model_replacement: '$1'
@@ -1831,7 +2137,7 @@ device_parsers:
   # Benss
   # @ref: http://www.benss.net/
   #########
-  - regex: '; *(JC-[^;/]*) Build'
+  - regex: '; {0,2}(JC-[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: 'Benss $1'
     brand_replacement: 'Benss'
     model_replacement: '$1'
@@ -1841,7 +2147,7 @@ device_parsers:
   # @ref: http://uk.blackberry.com/
   # @note: Android Apps seams to be used here
   #########
-  - regex: '; *(BB) ([^;/]+) Build'
+  - regex: '; {0,2}(BB) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Blackberry'
     model_replacement: '$2'
@@ -1850,11 +2156,11 @@ device_parsers:
   # Blackbird
   # @ref: http://iblackbird.co.kr
   #########
-  - regex: '; *(BlackBird)[ _](I8.*) Build'
+  - regex: '; {0,2}(BlackBird)[ _](I8.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
-  - regex: '; *(BlackBird)[ _](.*) Build'
+  - regex: '; {0,2}(BlackBird)[ _](.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -1864,7 +2170,7 @@ device_parsers:
   # @ref: http://www.blaupunkt.com
   #########
   # Endeavour
-  - regex: '; *([0-9]+BP[EM][^;/]*|Endeavour[^;/]+) Build'
+  - regex: '; {0,2}([0-9]+BP[EM][^;/]*|Endeavour[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Blaupunkt $1'
     brand_replacement: 'Blaupunkt'
     model_replacement: '$1'
@@ -1873,12 +2179,12 @@ device_parsers:
   # Blu
   # @ref: http://bluproducts.com
   #########
-  - regex: '; *((?:BLU|Blu)[ _\-])([^;/]+) Build'
+  - regex: '; {0,2}((?:BLU|Blu)[ _\-])([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Blu'
     model_replacement: '$2'
   # BMOBILE = operator branded device
-  - regex: '; *(?:BMOBILE )?(Blu|BLU|DASH [^;/]+|VIVO 4\.3|TANK 4\.5) Build'
+  - regex: '; {0,2}(?:BMOBILE )?(Blu|BLU|DASH [^;/]{1,100}|VIVO 4\.3|TANK 4\.5)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Blu'
     model_replacement: '$1'
@@ -1888,7 +2194,7 @@ device_parsers:
   # @ref: http://www.blusens.com/es/?sg=1&sv=al&roc=1
   #########
   # tablet
-  - regex: '; *(TOUCH\d[^;/]+) Build'
+  - regex: '; {0,2}(TOUCH\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Blusens'
     model_replacement: '$1'
@@ -1899,7 +2205,7 @@ device_parsers:
   # @note: Might collide with Maxx as AX is used also there.
   #########
   # smartphone
-  - regex: '; *(AX5\d+) Build'
+  - regex: '; {0,2}(AX5\d+)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Bmobile'
     model_replacement: '$1'
@@ -1908,11 +2214,11 @@ device_parsers:
   # bq
   # @ref: http://bqreaders.com
   #########
-  - regex: '; *([Bb]q) ([^;/]+);? Build'
+  - regex: '; {0,2}([Bb]q) ([^;/]{1,100}?);?(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'bq'
     model_replacement: '$2'
-  - regex: '; *(Maxwell [^;/]+) Build'
+  - regex: '; {0,2}(Maxwell [^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'bq'
     model_replacement: '$1'
@@ -1921,7 +2227,7 @@ device_parsers:
   # Braun Phototechnik
   # @ref: http://www.braun-phototechnik.de/en/products/list/~pcat.250/Tablet-PC.html
   #########
-  - regex: '; *((?:B-Tab|B-TAB) ?\d[^;/]+) Build'
+  - regex: '; {0,2}((?:B-Tab|B-TAB) ?\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Braun'
     model_replacement: '$1'
@@ -1930,7 +2236,7 @@ device_parsers:
   # Broncho
   # @ref: http://www.broncho.cn/
   #########
-  - regex: '; *(Broncho) ([^;/]+) Build'
+  - regex: '; {0,2}(Broncho) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -1939,7 +2245,7 @@ device_parsers:
   # Captiva
   # @ref: http://www.captiva-power.de
   #########
-  - regex: '; *CAPTIVA ([^;/]+) Build'
+  - regex: '; {0,2}CAPTIVA ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Captiva $1'
     brand_replacement: 'Captiva'
     model_replacement: '$1'
@@ -1948,7 +2254,7 @@ device_parsers:
   # Casio
   # @ref: http://www.casiogzone.com/
   #########
-  - regex: '; *(C771|CAL21|IS11CA) Build'
+  - regex: '; {0,2}(C771|CAL21|IS11CA)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Casio'
     model_replacement: '$1'
@@ -1957,15 +2263,15 @@ device_parsers:
   # Cat
   # @ref: http://www.cat-sound.com
   #########
-  - regex: '; *(?:Cat|CAT) ([^;/]+) Build'
+  - regex: '; {0,2}(?:Cat|CAT) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Cat $1'
     brand_replacement: 'Cat'
     model_replacement: '$1'
-  - regex: '; *(?:Cat)(Nova.*) Build'
+  - regex: '; {0,2}(?:Cat)(Nova.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Cat $1'
     brand_replacement: 'Cat'
     model_replacement: '$1'
-  - regex: '; *(INM8002KP|ADM8000KP_[AB]) Build'
+  - regex: '; {0,2}(INM8002KP|ADM8000KP_[AB])(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Cat'
     model_replacement: 'Tablet PHOENIX 8.1J0'
@@ -1975,7 +2281,7 @@ device_parsers:
   # @ref: http://www.celkonmobiles.com/?_a=products
   # @models: A10, A19Q, A101, A105, A107, A107\+, A112, A118, A119, A119Q, A15, A19, A20, A200, A220, A225, A22 Race, A27, A58, A59, A60, A62, A63, A64, A66, A67, A69, A75, A77, A79, A8\+, A83, A85, A86, A87, A89 Ultima, A9\+, A90, A900, A95, A97i, A98, AR 40, AR 45, AR 50, ML5
   #########
-  - regex: '; *(?:[Cc]elkon[ _\*]|CELKON[ _\*])([^;/\)]+) ?(?:Build|;|\))'
+  - regex: '; {0,2}(?:[Cc]elkon[ _\*]|CELKON[ _\*])([^;/\)]+) ?(?:Build|;|\))'
     device_replacement: '$1'
     brand_replacement: 'Celkon'
     model_replacement: '$1'
@@ -1983,12 +2289,12 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'Celkon'
     model_replacement: '$1'
-  - regex: '; *(CT)-?(\d+) Build'
+  - regex: '; {0,2}(CT)-?(\d+)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Celkon'
     model_replacement: '$1$2'
   # smartphones
-  - regex: '; *(A19|A19Q|A105|A107[^;/\)]*) ?(?:Build|;|\))'
+  - regex: '; {0,2}(A19|A19Q|A105|A107[^;/\)]*) ?(?:Build|;|\))'
     device_replacement: '$1'
     brand_replacement: 'Celkon'
     model_replacement: '$1'
@@ -1999,7 +2305,7 @@ device_parsers:
   # @brief: China manufacturer makes tablets for different small brands
   #         (eg. http://www.zeepad.net/index.html)
   #########
-  - regex: '; *(TPC[0-9]{4,5}) Build'
+  - regex: '; {0,2}(TPC[0-9]{4,5})(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'ChangJia'
     model_replacement: '$1'
@@ -2008,15 +2314,15 @@ device_parsers:
   # Cloudfone
   # @ref: http://www.cloudfonemobile.com/
   #########
-  - regex: '; *(Cloudfone)[ _](Excite)([^ ][^;/]+) Build'
+  - regex: '; {0,2}(Cloudfone)[ _](Excite)([^ ][^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2 $3'
     brand_replacement: 'Cloudfone'
     model_replacement: '$1 $2 $3'
-  - regex: '; *(Excite|ICE)[ _](\d+[^;/]+) Build'
+  - regex: '; {0,2}(Excite|ICE)[ _](\d+[^;/]{0,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Cloudfone $1 $2'
     brand_replacement: 'Cloudfone'
     model_replacement: 'Cloudfone $1 $2'
-  - regex: '; *(Cloudfone|CloudPad)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(Cloudfone|CloudPad)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Cloudfone'
     model_replacement: '$1 $2'
@@ -2025,7 +2331,7 @@ device_parsers:
   # Cmx
   # @ref: http://cmx.at/de/
   #########
-  - regex: '; *((?:Aquila|Clanga|Rapax)[^;/]+) Build'
+  - regex: '; {0,2}((?:Aquila|Clanga|Rapax)[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Cmx'
@@ -2036,7 +2342,7 @@ device_parsers:
   # @ref: http://cobykyros.com
   # @note: Be careful with MID\d{3} from MpMan or Manta
   #########
-  - regex: '; *(?:CFW-|Kyros )?(MID[0-9]{4}(?:[ABC]|SR|TV)?)(\(3G\)-4G| GB 8K| 3G| 8K| GB)? *(?:Build|[;\)])'
+  - regex: '; {0,2}(?:CFW-|Kyros )?(MID[0-9]{4}(?:[ABC]|SR|TV)?)(\(3G\)-4G| GB 8K| 3G| 8K| GB)? {0,2}(?:Build|[;\)])'
     device_replacement: 'CobyKyros $1$2'
     brand_replacement: 'CobyKyros'
     model_replacement: '$1$2'
@@ -2045,7 +2351,7 @@ device_parsers:
   # Coolpad
   # @ref: ??
   #########
-  - regex: '; *([^;/]*)Coolpad[ _]([^;/]+) Build'
+  - regex: '; {0,2}([^;/]{0,50})Coolpad[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Coolpad'
     model_replacement: '$1$2'
@@ -2054,7 +2360,7 @@ device_parsers:
   # Cube
   # @ref: http://www.cube-tablet.com/buy-products.html
   #########
-  - regex: '; *(CUBE[ _])?([KU][0-9]+ ?GT.*|A5300) Build'
+  - regex: '; {0,2}(CUBE[ _])?([KU][0-9]+ ?GT.{0,200}?|A5300)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1$2'
     brand_replacement: 'Cube'
@@ -2064,12 +2370,12 @@ device_parsers:
   # Cubot
   # @ref: http://www.cubotmall.com/
   #########
-  - regex: '; *CUBOT ([^;/]+) Build'
+  - regex: '; {0,2}CUBOT ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Cubot'
     model_replacement: '$1'
-  - regex: '; *(BOBBY) Build'
+  - regex: '; {0,2}(BOBBY)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Cubot'
@@ -2079,7 +2385,7 @@ device_parsers:
   # Danew
   # @ref: http://www.danew.com/produits-tablette.php
   #########
-  - regex: '; *(Dslide [^;/]+) Build'
+  - regex: '; {0,2}(Dslide [^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Danew'
     model_replacement: '$1'
@@ -2093,39 +2399,39 @@ device_parsers:
   # @ref: http://www.dell.com/in/p/mobile-xcd28/pd
   # @ref: http://www.dell.com/in/p/mobile-xcd35/pd
   #########
-  - regex: '; *(XCD)[ _]?(28|35) Build'
+  - regex: '; {0,2}(XCD)[ _]?(28|35)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1$2'
     brand_replacement: 'Dell'
     model_replacement: '$1$2'
-  - regex: '; *(001DL) Build'
+  - regex: '; {0,2}(001DL)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: 'Streak'
-  - regex: '; *(?:Dell|DELL) (Streak) Build'
+  - regex: '; {0,2}(?:Dell|DELL) (Streak)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: 'Streak'
-  - regex: '; *(101DL|GS01|Streak Pro[^;/]*) Build'
+  - regex: '; {0,2}(101DL|GS01|Streak Pro[^;/]{0,100})(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: 'Streak Pro'
-  - regex: '; *([Ss]treak ?7) Build'
+  - regex: '; {0,2}([Ss]treak ?7)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: 'Streak 7'
-  - regex: '; *(Mini-3iX) Build'
+  - regex: '; {0,2}(Mini-3iX)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: '$1'
-  - regex: '; *(?:Dell|DELL)[ _](Aero|Venue|Thunder|Mini.*|Streak[ _]Pro) Build'
+  - regex: '; {0,2}(?:Dell|DELL)[ _](Aero|Venue|Thunder|Mini.{0,200}?|Streak[ _]Pro)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: '$1'
-  - regex: '; *Dell[ _]([^;/]+) Build'
+  - regex: '; {0,2}Dell[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: '$1'
-  - regex: '; *Dell ([^;/]+) Build'
+  - regex: '; {0,2}Dell ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: '$1'
@@ -2134,7 +2440,7 @@ device_parsers:
   # Denver
   # @ref: http://www.denver-electronics.com/tablets1/
   #########
-  - regex: '; *(TA[CD]-\d+[^;/]*) Build'
+  - regex: '; {0,2}(TA[CD]-\d+[^;/]{0,100})(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Denver'
     model_replacement: '$1'
@@ -2143,7 +2449,7 @@ device_parsers:
   # Dex
   # @ref: http://dex.ua/
   #########
-  - regex: '; *(iP[789]\d{2}(?:-3G)?|IP10\d{2}(?:-8GB)?) Build'
+  - regex: '; {0,2}(iP[789]\d{2}(?:-3G)?|IP10\d{2}(?:-8GB)?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Dex'
     model_replacement: '$1'
@@ -2152,7 +2458,7 @@ device_parsers:
   # DNS AirTab
   # @ref: http://www.dns-shop.ru/
   #########
-  - regex: '; *(AirTab)[ _\-]([^;/]+) Build'
+  - regex: '; {0,2}(AirTab)[ _\-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'DNS'
     model_replacement: '$1 $2'
@@ -2161,43 +2467,43 @@ device_parsers:
   # Docomo (Operator Branded Device)
   # @ref: http://www.ipentec.com/document/document.aspx?page=android-useragent
   #########
-  - regex: '; *(F\-\d[^;/]+) Build'
+  - regex: '; {0,2}(F\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Fujitsu'
     model_replacement: '$1'
-  - regex: '; *(HT-03A) Build'
+  - regex: '; {0,2}(HT-03A)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'Magic'
-  - regex: '; *(HT\-\d[^;/]+) Build'
+  - regex: '; {0,2}(HT\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
-  - regex: '; *(L\-\d[^;/]+) Build'
+  - regex: '; {0,2}(L\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'LG'
     model_replacement: '$1'
-  - regex: '; *(N\-\d[^;/]+) Build'
+  - regex: '; {0,2}(N\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Nec'
     model_replacement: '$1'
-  - regex: '; *(P\-\d[^;/]+) Build'
+  - regex: '; {0,2}(P\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Panasonic'
     model_replacement: '$1'
-  - regex: '; *(SC\-\d[^;/]+) Build'
+  - regex: '; {0,2}(SC\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
-  - regex: '; *(SH\-\d[^;/]+) Build'
+  - regex: '; {0,2}(SH\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Sharp'
     model_replacement: '$1'
-  - regex: '; *(SO\-\d[^;/]+) Build'
+  - regex: '; {0,2}(SO\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'SonyEricsson'
     model_replacement: '$1'
-  - regex: '; *(T\-0[12][^;/]+) Build'
+  - regex: '; {0,2}(T\-0[12][^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Toshiba'
     model_replacement: '$1'
@@ -2206,7 +2512,7 @@ device_parsers:
   # DOOV
   # @ref: http://www.doov.com.cn/
   #########
-  - regex: '; *(DOOV)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(DOOV)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'DOOV'
     model_replacement: '$2'
@@ -2215,7 +2521,7 @@ device_parsers:
   # Enot
   # @ref: http://www.enot.ua/
   #########
-  - regex: '; *(Enot|ENOT)[ -]?([^;/]+) Build'
+  - regex: '; {0,2}(Enot|ENOT)[ -]?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Enot'
     model_replacement: '$2'
@@ -2224,11 +2530,11 @@ device_parsers:
   # Evercoss
   # @ref: http://evercoss.com/android/
   #########
-  - regex: '; *[^;/]+ Build/(?:CROSS|Cross)+[ _\-]([^\)]+)'
+  - regex: '; {0,2}[^;/]{1,100} Build/(?:CROSS|Cross)+[ _\-]([^\)]+)'
     device_replacement: 'CROSS $1'
     brand_replacement: 'Evercoss'
     model_replacement: 'Cross $1'
-  - regex: '; *(CROSS|Cross)[ _\-]([^;/]+) Build'
+  - regex: '; {0,2}(CROSS|Cross)[ _\-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Evercoss'
     model_replacement: 'Cross $2'
@@ -2237,7 +2543,7 @@ device_parsers:
   # Explay
   # @ref: http://explay.ru/
   #########
-  - regex: '; *Explay[_ ](.+?)(?:[\)]| Build)'
+  - regex: '; {0,2}Explay[_ ](.{1,200}?)(?:[\)]| Build)'
     device_replacement: '$1'
     brand_replacement: 'Explay'
     model_replacement: '$1'
@@ -2246,11 +2552,11 @@ device_parsers:
   # Fly
   # @ref: http://www.fly-phone.com/
   #########
-  - regex: '; *(IQ.*) Build'
+  - regex: '; {0,2}(IQ.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Fly'
     model_replacement: '$1'
-  - regex: '; *(Fly|FLY)[ _](IQ[^;]+|F[34]\d+[^;]*);? Build'
+  - regex: '; {0,2}(Fly|FLY)[ _](IQ[^;]{1,100}?|F[34]\d+[^;]{0,100}?);?(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Fly'
     model_replacement: '$2'
@@ -2259,7 +2565,7 @@ device_parsers:
   # Fujitsu
   # @ref: http://www.fujitsu.com/global/
   #########
-  - regex: '; *(M532|Q572|FJL21) Build/'
+  - regex: '; {0,2}(M532|Q572|FJL21)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Fujitsu'
     model_replacement: '$1'
@@ -2268,7 +2574,7 @@ device_parsers:
   # Galapad
   # @ref: http://www.galapad.net/product.html
   #########
-  - regex: '; *(G1) Build'
+  - regex: '; {0,2}(G1)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Galapad'
     model_replacement: '$1'
@@ -2277,7 +2583,7 @@ device_parsers:
   # Geeksphone
   # @ref: http://www.geeksphone.com/
   #########
-  - regex: '; *(Geeksphone) ([^;/]+) Build'
+  - regex: '; {0,2}(Geeksphone) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -2286,8 +2592,7 @@ device_parsers:
   # Gfive
   # @ref: http://www.gfivemobile.com/en
   #########
-  #- regex: '; *(G\'?FIVE) ([^;/]+) Build' # there is a problem with python yaml parser here
-  - regex: '; *(G[^F]?FIVE) ([^;/]+) Build'
+  - regex: '; {0,2}(G[^F]?FIVE) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Gfive'
     model_replacement: '$2'
@@ -2296,16 +2601,16 @@ device_parsers:
   # Gionee
   # @ref: http://www.gionee.com/
   #########
-  - regex: '; *(Gionee)[ _\-]([^;/]+)(?:/[^;/]+|) Build'
+  - regex: '; {0,2}(Gionee)[ _\-]([^;/]{1,100}?)(?:/[^;/]{1,100}|)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Gionee'
     model_replacement: '$2'
-  - regex: '; *(GN\d+[A-Z]?|INFINITY_PASSION|Ctrl_V1) Build'
+  - regex: '; {0,2}(GN\d+[A-Z]?|INFINITY_PASSION|Ctrl_V1)(?: Build|\) AppleWebKit)'
     device_replacement: 'Gionee $1'
     brand_replacement: 'Gionee'
     model_replacement: '$1'
-  - regex: '; *(E3) Build/JOP40D'
+  - regex: '; {0,2}(E3) Build/JOP40D'
     device_replacement: 'Gionee $1'
     brand_replacement: 'Gionee'
     model_replacement: '$1'
@@ -2319,11 +2624,11 @@ device_parsers:
   # GoClever
   # @ref: http://www.goclever.com
   #########
-  - regex: '; *((?:FONE|QUANTUM|INSIGNIA) \d+[^;/]*|PLAYTAB) Build'
+  - regex: '; {0,2}((?:FONE|QUANTUM|INSIGNIA) \d+[^;/]{0,100}|PLAYTAB)(?: Build|\) AppleWebKit)'
     device_replacement: 'GoClever $1'
     brand_replacement: 'GoClever'
     model_replacement: '$1'
-  - regex: '; *GOCLEVER ([^;/]+) Build'
+  - regex: '; {0,2}GOCLEVER ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'GoClever $1'
     brand_replacement: 'GoClever'
     model_replacement: '$1'
@@ -2332,11 +2637,11 @@ device_parsers:
   # Google
   # @ref: http://www.google.de/glass/start/
   #########
-  - regex: '; *(Glass \d+) Build'
+  - regex: '; {0,2}(Glass \d+)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Google'
     model_replacement: '$1'
-  - regex: '; *(Pixel.*) Build'
+  - regex: '; {0,2}(Pixel.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Google'
     model_replacement: '$1'
@@ -2345,7 +2650,7 @@ device_parsers:
   # Gigabyte
   # @ref: http://gsmart.gigabytecm.com/en/
   #########
-  - regex: '; *(GSmart)[ -]([^/]+) Build'
+  - regex: '; {0,2}(GSmart)[ -]([^/]{1,50})(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Gigabyte'
     model_replacement: '$1 $2'
@@ -2354,7 +2659,7 @@ device_parsers:
   # Freescale development boards
   # @ref: http://www.freescale.com/webapp/sps/site/prod_summary.jsp?code=IMX53QSB
   #########
-  - regex: '; *(imx5[13]_[^/]+) Build'
+  - regex: '; {0,2}(imx5[13]_[^/]{1,50})(?: Build|\) AppleWebKit)'
     device_replacement: 'Freescale $1'
     brand_replacement: 'Freescale'
     model_replacement: '$1'
@@ -2364,11 +2669,11 @@ device_parsers:
   # @ref: http://www.haier.com/
   # @ref: http://www.haier.com/de/produkte/tablet/
   #########
-  - regex: '; *Haier[ _\-]([^/]+) Build'
+  - regex: '; {0,2}Haier[ _\-]([^/]{1,50})(?: Build|\) AppleWebKit)'
     device_replacement: 'Haier $1'
     brand_replacement: 'Haier'
     model_replacement: '$1'
-  - regex: '; *(PAD1016) Build'
+  - regex: '; {0,2}(PAD1016)(?: Build|\) AppleWebKit)'
     device_replacement: 'Haipad $1'
     brand_replacement: 'Haipad'
     model_replacement: '$1'
@@ -2378,7 +2683,7 @@ device_parsers:
   # @ref: http://www.haipad.net/
   # @models: V7P|M7SM7S|M9XM9X|M7XM7X|M9|M8|M7-M|M1002|M7|M701
   #########
-  - regex: '; *(M701|M7|M8|M9) Build'
+  - regex: '; {0,2}(M701|M7|M8|M9)(?: Build|\) AppleWebKit)'
     device_replacement: 'Haipad $1'
     brand_replacement: 'Haipad'
     model_replacement: '$1'
@@ -2388,7 +2693,7 @@ device_parsers:
   # @ref: http://www.hannspree.eu/
   # @models: SN10T1|SN10T2|SN70T31B|SN70T32W
   #########
-  - regex: '; *(SN\d+T[^;\)/]*)(?: Build|[;\)])'
+  - regex: '; {0,2}(SN\d+T[^;\)/]*)(?: Build|[;\)])'
     device_replacement: 'Hannspree $1'
     brand_replacement: 'Hannspree'
     model_replacement: '$1'
@@ -2397,11 +2702,11 @@ device_parsers:
   # HCLme
   # @ref: http://www.hclmetablet.com/india/
   #########
-  - regex: 'Build/HCL ME Tablet ([^;\)]+)[\);]'
+  - regex: 'Build/HCL ME Tablet ([^;\)]{1,3})[\);]'
     device_replacement: 'HCLme $1'
     brand_replacement: 'HCLme'
     model_replacement: '$1'
-  - regex: '; *([^;\/]+) Build/HCL'
+  - regex: '; {0,2}([^;\/]+) Build/HCL'
     device_replacement: 'HCLme $1'
     brand_replacement: 'HCLme'
     model_replacement: '$1'
@@ -2410,7 +2715,7 @@ device_parsers:
   # Hena
   # @ref: http://www.henadigital.com/en/product/index.asp?id=6
   #########
-  - regex: '; *(MID-?\d{4}C[EM]) Build'
+  - regex: '; {0,2}(MID-?\d{4}C[EM])(?: Build|\) AppleWebKit)'
     device_replacement: 'Hena $1'
     brand_replacement: 'Hena'
     model_replacement: '$1'
@@ -2419,11 +2724,11 @@ device_parsers:
   # Hisense
   # @ref: http://www.hisense.com/
   #########
-  - regex: '; *(EG\d{2,}|HS-[^;/]+|MIRA[^;/]+) Build'
+  - regex: '; {0,2}(EG\d{2,}|HS-[^;/]{1,100}|MIRA[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Hisense $1'
     brand_replacement: 'Hisense'
     model_replacement: '$1'
-  - regex: '; *(andromax[^;/]+) Build'
+  - regex: '; {0,2}(andromax[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Hisense $1'
     brand_replacement: 'Hisense'
@@ -2433,7 +2738,7 @@ device_parsers:
   # hitech
   # @ref: http://www.hitech-mobiles.com/
   #########
-  - regex: '; *(?:AMAZE[ _](S\d+)|(S\d+)[ _]AMAZE) Build'
+  - regex: '; {0,2}(?:AMAZE[ _](S\d+)|(S\d+)[ _]AMAZE)(?: Build|\) AppleWebKit)'
     device_replacement: 'AMAZE $1$2'
     brand_replacement: 'hitech'
     model_replacement: 'AMAZE $1$2'
@@ -2442,15 +2747,15 @@ device_parsers:
   # HP
   # @ref: http://www.hp.com/
   #########
-  - regex: '; *(PlayBook) Build'
+  - regex: '; {0,2}(PlayBook)(?: Build|\) AppleWebKit)'
     device_replacement: 'HP $1'
     brand_replacement: 'HP'
     model_replacement: '$1'
-  - regex: '; *HP ([^/]+) Build'
+  - regex: '; {0,2}HP ([^/]{1,50})(?: Build|\) AppleWebKit)'
     device_replacement: 'HP $1'
     brand_replacement: 'HP'
     model_replacement: '$1'
-  - regex: '; *([^/]+_tenderloin) Build'
+  - regex: '; {0,2}([^/]{1,30}_tenderloin)(?: Build|\) AppleWebKit)'
     device_replacement: 'HP TouchPad'
     brand_replacement: 'HP'
     model_replacement: 'TouchPad'
@@ -2460,58 +2765,66 @@ device_parsers:
   # @ref: http://www.huaweidevice.com
   # @note: Needs to be before HTC due to Desire HD Build on U8815
   #########
-  - regex: '; *(HUAWEI |Huawei-|)([UY][^;/]+) Build/(?:Huawei|HUAWEI)([UY][^\);]+)\)'
+  - regex: '; {0,2}(HUAWEI |Huawei-|)([UY][^;/]{1,100}) Build/(?:Huawei|HUAWEI)([UY][^\);]+)\)'
     device_replacement: '$1$2'
     brand_replacement: 'Huawei'
     model_replacement: '$2'
-  - regex: '; *([^;/]+) Build[/ ]Huawei(MT1-U06|[A-Z]+\d+[^\);]+)[^\);]*\)'
+  - regex: '; {0,2}([^;/]{1,100}) Build[/ ]Huawei(MT1-U06|[A-Z]{1,50}\d+[^\);]{1,50})\)'
     device_replacement: '$1'
     brand_replacement: 'Huawei'
     model_replacement: '$2'
-  - regex: '; *(S7|M860) Build'
-    device_replacement: '$1'
-    brand_replacement: 'Huawei'
-    model_replacement: '$1'
-  - regex: '; *((?:HUAWEI|Huawei)[ \-]?)(MediaPad) Build'
-    device_replacement: '$1$2'
-    brand_replacement: 'Huawei'
-    model_replacement: '$2'
-  - regex: '; *((?:HUAWEI[ _]?|Huawei[ _]|)Ascend[ _])([^;/]+) Build'
-    device_replacement: '$1$2'
-    brand_replacement: 'Huawei'
-    model_replacement: '$2'
-  - regex: '; *((?:HUAWEI|Huawei)[ _\-]?)((?:G700-|MT-)[^;/]+) Build'
-    device_replacement: '$1$2'
-    brand_replacement: 'Huawei'
-    model_replacement: '$2'
-  - regex: '; *((?:HUAWEI|Huawei)[ _\-]?)([^;/]+) Build'
-    device_replacement: '$1$2'
-    brand_replacement: 'Huawei'
-    model_replacement: '$2'
-  - regex: '; *(MediaPad[^;]+|SpringBoard) Build/Huawei'
+  - regex: '; {0,2}(S7|M860) Build'
     device_replacement: '$1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'
-  - regex: '; *([^;]+) Build/(?:Huawei|HUAWEI)'
+  - regex: '; {0,2}((?:HUAWEI|Huawei)[ \-]?)(MediaPad) Build'
+    device_replacement: '$1$2'
+    brand_replacement: 'Huawei'
+    model_replacement: '$2'
+  - regex: '; {0,2}((?:HUAWEI[ _]?|Huawei[ _]|)Ascend[ _])([^;/]{1,100}) Build'
+    device_replacement: '$1$2'
+    brand_replacement: 'Huawei'
+    model_replacement: '$2'
+  - regex: '; {0,2}((?:HUAWEI|Huawei)[ _\-]?)((?:G700-|MT-)[^;/]{1,100}) Build'
+    device_replacement: '$1$2'
+    brand_replacement: 'Huawei'
+    model_replacement: '$2'
+  - regex: '; {0,2}((?:HUAWEI|Huawei)[ _\-]?)([^;/]{1,100}) Build'
+    device_replacement: '$1$2'
+    brand_replacement: 'Huawei'
+    model_replacement: '$2'
+  - regex: '; {0,2}(MediaPad[^;]{1,200}|SpringBoard) Build/Huawei'
     device_replacement: '$1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'
-  - regex: '; *([Uu])([89]\d{3}) Build'
+  - regex: '; {0,2}([^;]{1,200}) Build/(?:Huawei|HUAWEI)'
+    device_replacement: '$1'
+    brand_replacement: 'Huawei'
+    model_replacement: '$1'
+  - regex: '; {0,2}([Uu])([89]\d{3}) Build'
     device_replacement: '$1$2'
     brand_replacement: 'Huawei'
     model_replacement: 'U$2'
-  - regex: '; *(?:Ideos |IDEOS )(S7) Build'
+  - regex: '; {0,2}(?:Ideos |IDEOS )(S7) Build'
     device_replacement: 'Huawei Ideos$1'
     brand_replacement: 'Huawei'
     model_replacement: 'Ideos$1'
-  - regex: '; *(?:Ideos |IDEOS )([^;/]+\s*|\s*)Build'
+  - regex: '; {0,2}(?:Ideos |IDEOS )([^;/]{1,50}\s{0,5}|\s{0,5})Build'
     device_replacement: 'Huawei Ideos$1'
     brand_replacement: 'Huawei'
     model_replacement: 'Ideos$1'
-  - regex: '; *(Orange Daytona|Pulse|Pulse Mini|Vodafone 858|C8500|C8600|C8650|C8660|Nexus 6P|ATH-.+?) Build[/ ]'
+  - regex: '; {0,2}(Orange Daytona|Pulse|Pulse Mini|Vodafone 858|C8500|C8600|C8650|C8660|Nexus 6P|ATH-.{1,200}?) Build[/ ]'
     device_replacement: 'Huawei $1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'
+  - regex: '; {0,2}((?:[A-Z]{3})\-L[A-Za0-9]{2})[\)]'
+    device_replacement: 'Huawei $1'
+    brand_replacement: 'Huawei'
+    model_replacement: '$1'
+  - regex: '; {0,2}([^;]{1,200}) Build/(HONOR|Honor)'
+    device_replacement: 'Huawei Honor $1'
+    brand_replacement: 'Huawei'
+    model_replacement: 'Honor $1'
 
   #########
   # HTC
@@ -2519,7 +2832,7 @@ device_parsers:
   # @ref: http://en.wikipedia.org/wiki/List_of_HTC_phones
   #########
 
-  - regex: '; *HTC[ _]([^;]+); Windows Phone'
+  - regex: '; {0,2}HTC[ _]([^;]{1,200}); Windows Phone'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
@@ -2527,59 +2840,59 @@ device_parsers:
   # Android HTC with Version Number matcher
   # ; HTC_0P3Z11/1.12.161.3 Build
   # ;HTC_A3335 V2.38.841.1 Build
-  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
+  - regex: '; {0,2}(?:HTC[ _/])+([^ _/]+)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: {0,2}Build|\))'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
-  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)|)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
+  - regex: '; {0,2}(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)|)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: {0,2}Build|\))'
     device_replacement: 'HTC $1 $2'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2'
-  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)|)|)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
+  - regex: '; {0,2}(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)|)|)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: {0,2}Build|\))'
     device_replacement: 'HTC $1 $2 $3'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2 $3'
-  - regex: '; *(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)|)|)|)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: *Build|\))'
+  - regex: '; {0,2}(?:HTC[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)|)|)|)(?:[/\\]1\.0 | V|/| +)\d+\.\d[\d\.]*(?: {0,2}Build|\))'
     device_replacement: 'HTC $1 $2 $3 $4'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2 $3 $4'
 
   # Android HTC without Version Number matcher
-  - regex: '; *(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/;]+)(?: *Build|[;\)]| - )'
+  - regex: '; {0,2}(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/;]+)(?: {0,2}Build|[;\)]| - )'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
-  - regex: '; *(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/]+)(?:[ _/]([^ _/;\)]+)|)(?: *Build|[;\)]| - )'
+  - regex: '; {0,2}(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/]+)(?:[ _/]([^ _/;\)]+)|)(?: {0,2}Build|[;\)]| - )'
     device_replacement: 'HTC $1 $2'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2'
-  - regex: '; *(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/;\)]+)|)|)(?: *Build|[;\)]| - )'
+  - regex: '; {0,2}(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/;\)]+)|)|)(?: {0,2}Build|[;\)]| - )'
     device_replacement: 'HTC $1 $2 $3'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2 $3'
-  - regex: '; *(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ /;]+)|)|)|)(?: *Build|[;\)]| - )'
+  - regex: '; {0,2}(?:(?:HTC|htc)(?:_blocked|)[ _/])+([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ _/]+)(?:[ _/]([^ /;]+)|)|)|)(?: {0,2}Build|[;\)]| - )'
     device_replacement: 'HTC $1 $2 $3 $4'
     brand_replacement: 'HTC'
     model_replacement: '$1 $2 $3 $4'
 
   # HTC Streaming Player
-  - regex: 'HTC Streaming Player [^\/]*/[^\/]*/ htc_([^/]+) /'
+  - regex: 'HTC Streaming Player [^\/]{0,30}/[^\/]{0,10}/ htc_([^/]{1,10}) /'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
   # general matcher for anything else
-  - regex: '(?:[;,] *|^)(?:htccn_chs-|)HTC[ _-]?([^;]+?)(?: *Build|clay|Android|-?Mozilla| Opera| Profile| UNTRUSTED|[;/\(\)]|$)'
+  - regex: '(?:[;,] {0,2}|^)(?:htccn_chs-|)HTC[ _-]?([^;]{1,200}?)(?: {0,2}Build|clay|Android|-?Mozilla| Opera| Profile| UNTRUSTED|[;/\(\)]|$)'
     regex_flag: 'i'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
   # Android matchers without HTC
-  - regex: '; *(A6277|ADR6200|ADR6300|ADR6350|ADR6400[A-Z]*|ADR6425[A-Z]*|APX515CKT|ARIA|Desire[^_ ]*|Dream|EndeavorU|Eris|Evo|Flyer|HD2|Hero|HERO200|Hero CDMA|HTL21|Incredible|Inspire[A-Z0-9]*|Legend|Liberty|Nexus ?(?:One|HD2)|One|One S C2|One[ _]?(?:S|V|X\+?)\w*|PC36100|PG06100|PG86100|S31HT|Sensation|Wildfire)(?: Build|[/;\(\)])'
+  - regex: '; {0,2}(A6277|ADR6200|ADR6300|ADR6350|ADR6400[A-Z]*|ADR6425[A-Z]*|APX515CKT|ARIA|Desire[^_ ]*|Dream|EndeavorU|Eris|Evo|Flyer|HD2|Hero|HERO200|Hero CDMA|HTL21|Incredible|Inspire[A-Z0-9]*|Legend|Liberty|Nexus ?(?:One|HD2)|One|One S C2|One[ _]?(?:S|V|X\+?)\w*|PC36100|PG06100|PG86100|S31HT|Sensation|Wildfire)(?: Build|[/;\(\)])'
     regex_flag: 'i'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
-  - regex: '; *(ADR6200|ADR6400L|ADR6425LVW|Amaze|DesireS?|EndeavorU|Eris|EVO|Evo\d[A-Z]+|HD2|IncredibleS?|Inspire[A-Z0-9]*|Inspire[A-Z0-9]*|Sensation[A-Z0-9]*|Wildfire)[ _-](.+?)(?:[/;\)]|Build|MIUI|1\.0)'
+  - regex: '; {0,2}(ADR6200|ADR6400L|ADR6425LVW|Amaze|DesireS?|EndeavorU|Eris|EVO|Evo\d[A-Z]+|HD2|IncredibleS?|Inspire[A-Z0-9]*|Inspire[A-Z0-9]*|Sensation[A-Z0-9]*|Wildfire)[ _-](.{1,200}?)(?:[/;\)]|Build|MIUI|1\.0)'
     regex_flag: 'i'
     device_replacement: 'HTC $1 $2'
     brand_replacement: 'HTC'
@@ -2589,16 +2902,16 @@ device_parsers:
   # Hyundai
   # @ref: http://www.hyundaitechnologies.com
   #########
-  - regex: '; *HYUNDAI (T\d[^/]*) Build'
+  - regex: '; {0,2}HYUNDAI (T\d[^/]{0,10})(?: Build|\) AppleWebKit)'
     device_replacement: 'Hyundai $1'
     brand_replacement: 'Hyundai'
     model_replacement: '$1'
-  - regex: '; *HYUNDAI ([^;/]+) Build'
+  - regex: '; {0,2}HYUNDAI ([^;/]{1,10}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Hyundai $1'
     brand_replacement: 'Hyundai'
     model_replacement: '$1'
   # X900? http://www.amazon.com/Hyundai-X900-Retina-Android-Bluetooth/dp/B00AO07H3O
-  - regex: '; *(X700|Hold X|MB-6900) Build'
+  - regex: '; {0,2}(X700|Hold X|MB-6900)(?: Build|\) AppleWebKit)'
     device_replacement: 'Hyundai $1'
     brand_replacement: 'Hyundai'
     model_replacement: '$1'
@@ -2607,12 +2920,12 @@ device_parsers:
   # iBall
   # @ref: http://www.iball.co.in/Category/Mobiles/22
   #########
-  - regex: '; *(?:iBall[ _\-]|)(Andi)[ _]?(\d[^;/]*) Build'
+  - regex: '; {0,2}(?:iBall[ _\-]|)(Andi)[ _]?(\d[^;/]*)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'iBall'
     model_replacement: '$1 $2'
-  - regex: '; *(IBall)(?:[ _]([^;/]+)|) Build'
+  - regex: '; {0,2}(IBall)(?:[ _]([^;/]{1,100}?)|)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'iBall'
@@ -2622,7 +2935,7 @@ device_parsers:
   # IconBIT
   # @ref: http://www.iconbit.com/catalog/tablets/
   #########
-  - regex: '; *(NT-\d+[^ ;/]*|Net[Tt]AB [^;/]+|Mercury [A-Z]+|iconBIT)(?: S/N:[^;/]+|) Build'
+  - regex: '; {0,2}(NT-\d+[^ ;/]{0,50}|Net[Tt]AB [^;/]{1,50}|Mercury [A-Z]{1,50}|iconBIT)(?: S/N:[^;/]{1,50}|)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'IconBIT'
     model_replacement: '$1'
@@ -2631,7 +2944,7 @@ device_parsers:
   # IMO
   # @ref: http://www.ponselimo.com/
   #########
-  - regex: '; *(IMO)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(IMO)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'IMO'
@@ -2641,12 +2954,12 @@ device_parsers:
   # i-mobile
   # @ref: http://www.i-mobilephone.com/
   #########
-  - regex: '; *i-?mobile[ _]([^/]+) Build/'
+  - regex: '; {0,2}i-?mobile[ _]([^/]{1,50})(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'i-mobile $1'
     brand_replacement: 'imobile'
     model_replacement: '$1'
-  - regex: '; *(i-(?:style|note)[^/]*) Build/'
+  - regex: '; {0,2}(i-(?:style|note)[^/]{0,10})(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'i-mobile $1'
     brand_replacement: 'imobile'
@@ -2656,7 +2969,7 @@ device_parsers:
   # Impression
   # @ref: http://impression.ua/planshetnye-kompyutery
   #########
-  - regex: '; *(ImPAD) ?(\d+(?:.)*) Build'
+  - regex: '; {0,2}(ImPAD) ?(\d+(?:.){0,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Impression'
     model_replacement: '$1 $2'
@@ -2665,7 +2978,7 @@ device_parsers:
   # Infinix
   # @ref: http://www.infinixmobility.com/index.html
   #########
-  - regex: '; *(Infinix)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(Infinix)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Infinix'
     model_replacement: '$2'
@@ -2674,7 +2987,7 @@ device_parsers:
   # Informer
   # @ref: ??
   #########
-  - regex: '; *(Informer)[ \-]([^;/]+) Build'
+  - regex: '; {0,2}(Informer)[ \-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Informer'
     model_replacement: '$2'
@@ -2684,7 +2997,7 @@ device_parsers:
   # @ref: http://www.intenso.de
   # @models: 7":TAB 714,TAB 724;8":TAB 814,TAB 824;10":TAB 1004
   #########
-  - regex: '; *(TAB) ?([78][12]4) Build'
+  - regex: '; {0,2}(TAB) ?([78][12]4)(?: Build|\) AppleWebKit)'
     device_replacement: 'Intenso $1'
     brand_replacement: 'Intenso'
     model_replacement: '$1 $2'
@@ -2695,21 +3008,21 @@ device_parsers:
   # @note: Zync also offers a "Cloud Z5" device
   #########
   # smartphones
-  - regex: '; *(?:Intex[ _]|)(AQUA|Aqua)([ _\.\-])([^;/]+) *(?:Build|;)'
+  - regex: '; {0,2}(?:Intex[ _]|)(AQUA|Aqua)([ _\.\-])([^;/]{1,100}?) {0,2}(?:Build|;)'
     device_replacement: '$1$2$3'
     brand_replacement: 'Intex'
     model_replacement: '$1 $3'
   # matches "INTEX CLOUD X1"
-  - regex: '; *(?:INTEX|Intex)(?:[_ ]([^\ _;/]+))(?:[_ ]([^\ _;/]+)|) *(?:Build|;)'
+  - regex: '; {0,2}(?:INTEX|Intex)(?:[_ ]([^\ _;/]+))(?:[_ ]([^\ _;/]+)|) {0,2}(?:Build|;)'
     device_replacement: '$1 $2'
     brand_replacement: 'Intex'
     model_replacement: '$1 $2'
   # tablets
-  - regex: '; *([iI]Buddy)[ _]?(Connect)(?:_|\?_| |)([^;/]*) *(?:Build|;)'
+  - regex: '; {0,2}([iI]Buddy)[ _]?(Connect)(?:_|\?_| |)([^;/]{0,50}) {0,2}(?:Build|;)'
     device_replacement: '$1 $2 $3'
     brand_replacement: 'Intex'
     model_replacement: 'iBuddy $2 $3'
-  - regex: '; *(I-Buddy)[ _]([^;/]+) *(?:Build|;)'
+  - regex: '; {0,2}(I-Buddy)[ _]([^;/]{1,100}?) {0,2}(?:Build|;)'
     device_replacement: '$1 $2'
     brand_replacement: 'Intex'
     model_replacement: 'iBuddy $2'
@@ -2718,7 +3031,7 @@ device_parsers:
   # iOCEAN
   # @ref: http://www.iocean.cc/
   #########
-  - regex: '; *(iOCEAN) ([^/]+) Build'
+  - regex: '; {0,2}(iOCEAN) ([^/]{1,50})(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'iOCEAN'
@@ -2728,7 +3041,7 @@ device_parsers:
   # i.onik
   # @ref: http://www.i-onik.de/
   #########
-  - regex: '; *(TP\d+(?:\.\d+|)\-\d[^;/]+) Build'
+  - regex: '; {0,2}(TP\d+(?:\.\d+|)\-\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'ionik $1'
     brand_replacement: 'ionik'
     model_replacement: '$1'
@@ -2737,9 +3050,18 @@ device_parsers:
   # IRU.ru
   # @ref: http://www.iru.ru/catalog/soho/planetable/
   #########
-  - regex: '; *(M702pro) Build'
+  - regex: '; {0,2}(M702pro)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Iru'
+    model_replacement: '$1'
+
+  #########
+  # Itel Mobile
+  # @ref: https://www.itel-mobile.com/global/products/
+  #########
+  - regex: '; {0,2}itel ([^;/]*)(?: Build|\) AppleWebKit)'
+    device_replacement: 'Itel $1'
+    brand_replacement: 'Itel'
     model_replacement: '$1'
 
   #########
@@ -2747,11 +3069,11 @@ device_parsers:
   # @ref: http://www.ivio.com/mobile.php
   # @models: DG80,DG20,DE38,DE88,MD70
   #########
-  - regex: '; *(DE88Plus|MD70) Build'
+  - regex: '; {0,2}(DE88Plus|MD70)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Ivio'
     model_replacement: '$1'
-  - regex: '; *IVIO[_\-]([^;/]+) Build'
+  - regex: '; {0,2}IVIO[_\-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Ivio'
     model_replacement: '$1'
@@ -2760,7 +3082,7 @@ device_parsers:
   # Jaytech
   # @ref: http://www.jay-tech.de/jaytech/servlet/frontend/
   #########
-  - regex: '; *(TPC-\d+|JAY-TECH) Build'
+  - regex: '; {0,2}(TPC-\d+|JAY-TECH)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Jaytech'
     model_replacement: '$1'
@@ -2769,7 +3091,7 @@ device_parsers:
   # Jiayu
   # @ref: http://www.ejiayu.com/en/Product.html
   #########
-  - regex: '; *(JY-[^;/]+|G[234]S?) Build'
+  - regex: '; {0,2}(JY-[^;/]{1,100}|G[234]S?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Jiayu'
     model_replacement: '$1'
@@ -2778,7 +3100,7 @@ device_parsers:
   # JXD
   # @ref: http://www.jxd.hk/
   #########
-  - regex: '; *(JXD)[ _\-]([^;/]+) Build'
+  - regex: '; {0,2}(JXD)[ _\-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'JXD'
     model_replacement: '$2'
@@ -2787,16 +3109,16 @@ device_parsers:
   # Karbonn
   # @ref: http://www.karbonnmobiles.com/products_tablet.php
   #########
-  - regex: '; *Karbonn[ _]?([^;/]+) *(?:Build|;)'
+  - regex: '; {0,2}Karbonn[ _]?([^;/]{1,100}) {0,2}(?:Build|;)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Karbonn'
     model_replacement: '$1'
-  - regex: '; *([^;]+) Build/Karbonn'
+  - regex: '; {0,2}([^;]{1,200}) Build/Karbonn'
     device_replacement: '$1'
     brand_replacement: 'Karbonn'
     model_replacement: '$1'
-  - regex: '; *(A11|A39|A37|A34|ST8|ST10|ST7|Smart Tab3|Smart Tab2|Titanium S\d) +Build'
+  - regex: '; {0,2}(A11|A39|A37|A34|ST8|ST10|ST7|Smart Tab3|Smart Tab2|Titanium S\d) +Build'
     device_replacement: '$1'
     brand_replacement: 'Karbonn'
     model_replacement: '$1'
@@ -2805,84 +3127,84 @@ device_parsers:
   # KDDI (Operator Branded Device)
   # @ref: http://www.ipentec.com/document/document.aspx?page=android-useragent
   #########
-  - regex: '; *(IS01|IS03|IS05|IS\d{2}SH) Build'
+  - regex: '; {0,2}(IS01|IS03|IS05|IS\d{2}SH)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Sharp'
     model_replacement: '$1'
-  - regex: '; *(IS04) Build'
+  - regex: '; {0,2}(IS04)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Regza'
     model_replacement: '$1'
-  - regex: '; *(IS06|IS\d{2}PT) Build'
+  - regex: '; {0,2}(IS06|IS\d{2}PT)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Pantech'
     model_replacement: '$1'
-  - regex: '; *(IS11S) Build'
+  - regex: '; {0,2}(IS11S)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'SonyEricsson'
     model_replacement: 'Xperia Acro'
-  - regex: '; *(IS11CA) Build'
+  - regex: '; {0,2}(IS11CA)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Casio'
     model_replacement: 'GzOne $1'
-  - regex: '; *(IS11LG) Build'
+  - regex: '; {0,2}(IS11LG)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'LG'
     model_replacement: 'Optimus X'
-  - regex: '; *(IS11N) Build'
+  - regex: '; {0,2}(IS11N)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Medias'
     model_replacement: '$1'
-  - regex: '; *(IS11PT) Build'
+  - regex: '; {0,2}(IS11PT)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Pantech'
     model_replacement: 'MIRACH'
-  - regex: '; *(IS12F) Build'
+  - regex: '; {0,2}(IS12F)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Fujitsu'
     model_replacement: 'Arrows ES'
   # @ref: https://ja.wikipedia.org/wiki/IS12M
-  - regex: '; *(IS12M) Build'
+  - regex: '; {0,2}(IS12M)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Motorola'
     model_replacement: 'XT909'
-  - regex: '; *(IS12S) Build'
+  - regex: '; {0,2}(IS12S)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'SonyEricsson'
     model_replacement: 'Xperia Acro HD'
-  - regex: '; *(ISW11F) Build'
+  - regex: '; {0,2}(ISW11F)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Fujitsu'
     model_replacement: 'Arrowz Z'
-  - regex: '; *(ISW11HT) Build'
+  - regex: '; {0,2}(ISW11HT)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'EVO'
-  - regex: '; *(ISW11K) Build'
+  - regex: '; {0,2}(ISW11K)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Kyocera'
     model_replacement: 'DIGNO'
-  - regex: '; *(ISW11M) Build'
+  - regex: '; {0,2}(ISW11M)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Motorola'
     model_replacement: 'Photon'
-  - regex: '; *(ISW11SC) Build'
+  - regex: '; {0,2}(ISW11SC)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Samsung'
     model_replacement: 'GALAXY S II WiMAX'
-  - regex: '; *(ISW12HT) Build'
+  - regex: '; {0,2}(ISW12HT)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'EVO 3D'
-  - regex: '; *(ISW13HT) Build'
+  - regex: '; {0,2}(ISW13HT)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'J'
-  - regex: '; *(ISW?[0-9]{2}[A-Z]{0,2}) Build'
+  - regex: '; {0,2}(ISW?[0-9]{2}[A-Z]{0,2})(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'KDDI'
     model_replacement: '$1'
-  - regex: '; *(INFOBAR [^;/]+) Build'
+  - regex: '; {0,2}(INFOBAR [^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'KDDI'
     model_replacement: '$1'
@@ -2891,7 +3213,7 @@ device_parsers:
   # Kingcom
   # @ref: http://www.e-kingcom.com
   #########
-  - regex: '; *(JOYPAD|Joypad)[ _]([^;/]+) Build/'
+  - regex: '; {0,2}(JOYPAD|Joypad)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Kingcom'
     model_replacement: '$1 $2'
@@ -2901,7 +3223,7 @@ device_parsers:
   # @ref: https://en.wikipedia.org/wiki/Kobo_Inc.
   # @ref: http://www.kobo.com/devices#tablets
   #########
-  - regex: '; *(Vox|VOX|Arc|K080) Build/'
+  - regex: '; {0,2}(Vox|VOX|Arc|K080)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Kobo'
@@ -2915,7 +3237,7 @@ device_parsers:
   # K-Touch
   # @ref: ??
   #########
-  - regex: '; *(K-Touch)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(K-Touch)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Ktouch'
@@ -2925,7 +3247,7 @@ device_parsers:
   # KT Tech
   # @ref: http://www.kttech.co.kr
   #########
-  - regex: '; *((?:EV|KM)-S\d+[A-Z]?) Build'
+  - regex: '; {0,2}((?:EV|KM)-S\d+[A-Z]?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'KTtech'
@@ -2935,7 +3257,7 @@ device_parsers:
   # Kyocera
   # @ref: http://www.android.com/devices/?country=all&m=kyocera
   #########
-  - regex: '; *(Zio|Hydro|Torque|Event|EVENT|Echo|Milano|Rise|URBANO PROGRESSO|WX04K|WX06K|WX10K|KYL21|101K|C5[12]\d{2}) Build/'
+  - regex: '; {0,2}(Zio|Hydro|Torque|Event|EVENT|Echo|Milano|Rise|URBANO PROGRESSO|WX04K|WX06K|WX10K|KYL21|101K|C5[12]\d{2})(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Kyocera'
     model_replacement: '$1'
@@ -2944,12 +3266,12 @@ device_parsers:
   # Lava
   # @ref: http://www.lavamobiles.com/
   #########
-  - regex: '; *(?:LAVA[ _]|)IRIS[ _\-]?([^/;\)]+) *(?:;|\)|Build)'
+  - regex: '; {0,2}(?:LAVA[ _]|)IRIS[ _\-]?([^/;\)]+) {0,2}(?:;|\)|Build)'
     regex_flag: 'i'
     device_replacement: 'Iris $1'
     brand_replacement: 'Lava'
     model_replacement: 'Iris $1'
-  - regex: '; *LAVA[ _]([^;/]+) Build'
+  - regex: '; {0,2}LAVA[ _]([^;/]{1,100}) Build'
     device_replacement: '$1'
     brand_replacement: 'Lava'
     model_replacement: '$1'
@@ -2958,7 +3280,7 @@ device_parsers:
   # Lemon
   # @ref: http://www.lemonmobiles.com/products.php?type=1
   #########
-  - regex: '; *(?:(Aspire A1)|(?:LEMON|Lemon)[ _]([^;/]+))_? Build'
+  - regex: '; {0,2}(?:(Aspire A1)|(?:LEMON|Lemon)[ _]([^;/]{1,100}))_?(?: Build|\) AppleWebKit)'
     device_replacement: 'Lemon $1$2'
     brand_replacement: 'Lemon'
     model_replacement: '$1$2'
@@ -2967,11 +3289,11 @@ device_parsers:
   # Lenco
   # @ref: http://www.lenco.com/c/tablets/
   #########
-  - regex: '; *(TAB-1012) Build/'
+  - regex: '; {0,2}(TAB-1012)(?: Build|\) AppleWebKit)'
     device_replacement: 'Lenco $1'
     brand_replacement: 'Lenco'
     model_replacement: '$1'
-  - regex: '; Lenco ([^;/]+) Build/'
+  - regex: '; Lenco ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Lenco $1'
     brand_replacement: 'Lenco'
     model_replacement: '$1'
@@ -2980,23 +3302,23 @@ device_parsers:
   # Lenovo
   # @ref: http://support.lenovo.com/en_GB/downloads/default.page?#
   #########
-  - regex: '; *(A1_07|A2107A-H|S2005A-H|S1-37AH0) Build'
+  - regex: '; {0,2}(A1_07|A2107A-H|S2005A-H|S1-37AH0) Build'
     device_replacement: '$1'
     brand_replacement: 'Lenovo'
     model_replacement: '$1'
-  - regex: '; *(Idea[Tp]ab)[ _]([^;/]+);? Build'
+  - regex: '; {0,2}(Idea[Tp]ab)[ _]([^;/]{1,100});? Build'
     device_replacement: 'Lenovo $1 $2'
     brand_replacement: 'Lenovo'
     model_replacement: '$1 $2'
-  - regex: '; *(Idea(?:Tab|pad)) ?([^;/]+) Build'
+  - regex: '; {0,2}(Idea(?:Tab|pad)) ?([^;/]{1,100}) Build'
     device_replacement: 'Lenovo $1 $2'
     brand_replacement: 'Lenovo'
     model_replacement: '$1 $2'
-  - regex: '; *(ThinkPad) ?(Tablet) Build/'
+  - regex: '; {0,2}(ThinkPad) ?(Tablet) Build/'
     device_replacement: 'Lenovo $1 $2'
     brand_replacement: 'Lenovo'
     model_replacement: '$1 $2'
-  - regex: '; *(?:LNV-|)(?:=?[Ll]enovo[ _\-]?|LENOVO[ _])(.+?)(?:Build|[;/\)])'
+  - regex: '; {0,2}(?:LNV-|)(?:=?[Ll]enovo[ _\-]?|LENOVO[ _])(.{1,200}?)(?:Build|[;/\)])'
     device_replacement: 'Lenovo $1'
     brand_replacement: 'Lenovo'
     model_replacement: '$1'
@@ -3004,11 +3326,11 @@ device_parsers:
     device_replacement: 'Lenovo $1 $2 $3'
     brand_replacement: 'Lenovo'
     model_replacement: '$1 $2 $3'
-  - regex: '; *(?:Ideapad |)K1 Build/'
+  - regex: '; {0,2}(?:Ideapad |)K1 Build/'
     device_replacement: 'Lenovo Ideapad K1'
     brand_replacement: 'Lenovo'
     model_replacement: 'Ideapad K1'
-  - regex: '; *(3GC101|3GW10[01]|A390) Build/'
+  - regex: '; {0,2}(3GC101|3GW10[01]|A390) Build/'
     device_replacement: '$1'
     brand_replacement: 'Lenovo'
     model_replacement: '$1'
@@ -3021,7 +3343,7 @@ device_parsers:
   # Lexibook
   # @ref: http://www.lexibook.com/fr
   #########
-  - regex: '; *(MFC\d+)[A-Z]{2}([^;,/]*),? Build'
+  - regex: '; {0,2}(MFC\d+)[A-Z]{2}([^;,/]*),?(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Lexibook'
     model_replacement: '$1$2'
@@ -3030,23 +3352,23 @@ device_parsers:
   # LG
   # @ref: http://www.lg.com/uk/mobile
   #########
-  - regex: '; *(E[34][0-9]{2}|LS[6-8][0-9]{2}|VS[6-9][0-9]+[^;/]+|Nexus 4|Nexus 5X?|GT540f?|Optimus (?:2X|G|4X HD)|OptimusX4HD) *(?:Build|;)'
+  - regex: '; {0,2}(E[34][0-9]{2}|LS[6-8][0-9]{2}|VS[6-9][0-9]+[^;/]{1,30}|Nexus 4|Nexus 5X?|GT540f?|Optimus (?:2X|G|4X HD)|OptimusX4HD) {0,2}(?:Build|;)'
     device_replacement: '$1'
     brand_replacement: 'LG'
     model_replacement: '$1'
-  - regex: '[;:] *(L-\d+[A-Z]|LGL\d+[A-Z]?)(?:/V\d+|) *(?:Build|[;\)])'
+  - regex: '[;:] {0,2}(L-\d+[A-Z]|LGL\d+[A-Z]?)(?:/V\d+|) {0,2}(?:Build|[;\)])'
     device_replacement: '$1'
     brand_replacement: 'LG'
     model_replacement: '$1'
-  - regex: '; *(LG-)([A-Z]{1,2}\d{2,}[^,;/\)\(]*?)(?:Build| V\d+|[,;/\)\(]|$)'
+  - regex: '; {0,2}(LG-)([A-Z]{1,2}\d{2,}[^,;/\)\(]*?)(?:Build| V\d+|[,;/\)\(]|$)'
     device_replacement: '$1$2'
     brand_replacement: 'LG'
     model_replacement: '$2'
-  - regex: '; *(LG[ \-]|LG)([^;/]+)[;/]? Build'
+  - regex: '; {0,2}(LG[ \-]|LG)([^;/]{1,100})[;/]? Build'
     device_replacement: '$1$2'
     brand_replacement: 'LG'
     model_replacement: '$2'
-  - regex: '^(LG)-([^;/]+)/ Mozilla/.*; Android'
+  - regex: '^(LG)-([^;/]{1,100})/ Mozilla/.{0,200}; Android'
     device_replacement: '$1 $2'
     brand_replacement: 'LG'
     model_replacement: '$2'
@@ -3059,11 +3381,11 @@ device_parsers:
   # Malata
   # @ref: http://www.malata.com/en/products.aspx?classid=680
   #########
-  - regex: '; *((?:SMB|smb)[^;/]+) Build/'
+  - regex: '; {0,2}((?:SMB|smb)[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Malata'
     model_replacement: '$1'
-  - regex: '; *(?:Malata|MALATA) ([^;/]+) Build/'
+  - regex: '; {0,2}(?:Malata|MALATA) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Malata'
     model_replacement: '$1'
@@ -3072,7 +3394,7 @@ device_parsers:
   # Manta
   # @ref: http://www.manta.com.pl/en
   #########
-  - regex: '; *(MS[45][0-9]{3}|MID0[568][NS]?|MID[1-9]|MID[78]0[1-9]|MID970[1-9]|MID100[1-9]) Build/'
+  - regex: '; {0,2}(MS[45][0-9]{3}|MID0[568][NS]?|MID[1-9]|MID[78]0[1-9]|MID970[1-9]|MID100[1-9])(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Manta'
     model_replacement: '$1'
@@ -3081,7 +3403,7 @@ device_parsers:
   # Match
   # @ref: http://www.match.net.cn/products.asp
   #########
-  - regex: '; *(M1052|M806|M9000|M9100|M9701|MID100|MID120|MID125|MID130|MID135|MID140|MID701|MID710|MID713|MID727|MID728|MID731|MID732|MID733|MID735|MID736|MID737|MID760|MID800|MID810|MID820|MID830|MID833|MID835|MID860|MID900|MID930|MID933|MID960|MID980) Build/'
+  - regex: '; {0,2}(M1052|M806|M9000|M9100|M9701|MID100|MID120|MID125|MID130|MID135|MID140|MID701|MID710|MID713|MID727|MID728|MID731|MID732|MID733|MID735|MID736|MID737|MID760|MID800|MID810|MID820|MID830|MID833|MID835|MID860|MID900|MID930|MID933|MID960|MID980)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Match'
     model_replacement: '$1'
@@ -3095,7 +3417,7 @@ device_parsers:
   #   Maxx MT150, Maxx MQ601, Maxx M2020, Maxx Sleek MX463neo, Maxx MX525, Maxx MX192-Tune, Maxx Genx Droid 7 AX353,
   # @note: Need more User-Agents!!!
   #########
-  - regex: '; *(GenxDroid7|MSD7.*|AX\d.*|Tab 701|Tab 722) Build/'
+  - regex: '; {0,2}(GenxDroid7|MSD7.{0,200}?|AX\d.{0,200}?|Tab 701|Tab 722)(?: Build|\) AppleWebKit)'
     device_replacement: 'Maxx $1'
     brand_replacement: 'Maxx'
     model_replacement: '$1'
@@ -3104,11 +3426,11 @@ device_parsers:
   # Mediacom
   # @ref: http://www.mediacomeurope.it/
   #########
-  - regex: '; *(M-PP[^;/]+|PhonePad ?\d{2,}[^;/]+) Build'
+  - regex: '; {0,2}(M-PP[^;/]{1,30}|PhonePad ?\d{2,}[^;/]{1,30}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Mediacom $1'
     brand_replacement: 'Mediacom'
     model_replacement: '$1'
-  - regex: '; *(M-MP[^;/]+|SmartPad ?\d{2,}[^;/]+) Build'
+  - regex: '; {0,2}(M-MP[^;/]{1,30}|SmartPad ?\d{2,}[^;/]{1,30}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Mediacom $1'
     brand_replacement: 'Mediacom'
     model_replacement: '$1'
@@ -3117,12 +3439,12 @@ device_parsers:
   # Medion
   # @ref: http://www.medion.com/en/
   #########
-  - regex: '; *(?:MD_|)LIFETAB[ _]([^;/]+) Build'
+  - regex: '; {0,2}(?:MD_|)LIFETAB[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Medion Lifetab $1'
     brand_replacement: 'Medion'
     model_replacement: 'Lifetab $1'
-  - regex: '; *MEDION ([^;/]+) Build'
+  - regex: '; {0,2}MEDION ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Medion $1'
     brand_replacement: 'Medion'
     model_replacement: '$1'
@@ -3131,11 +3453,11 @@ device_parsers:
   # Meizu
   # @ref: http://www.meizu.com
   #########
-  - regex: '; *(M030|M031|M035|M040|M065|m9) Build'
+  - regex: '; {0,2}(M030|M031|M035|M040|M065|m9)(?: Build|\) AppleWebKit)'
     device_replacement: 'Meizu $1'
     brand_replacement: 'Meizu'
     model_replacement: '$1'
-  - regex: '; *(?:meizu_|MEIZU )(.+?) *(?:Build|[;\)])'
+  - regex: '; {0,2}(?:meizu_|MEIZU )(.{1,200}?) {0,2}(?:Build|[;\)])'
     device_replacement: 'Meizu $1'
     brand_replacement: 'Meizu'
     model_replacement: '$1'
@@ -3144,28 +3466,28 @@ device_parsers:
   # Micromax
   # @ref: http://www.micromaxinfo.com
   #########
-  - regex: '; *(?:Micromax[ _](A111|A240)|(A111|A240)) Build'
+  - regex: '; {0,2}(?:Micromax[ _](A111|A240)|(A111|A240)) Build'
     regex_flag: 'i'
     device_replacement: 'Micromax $1$2'
     brand_replacement: 'Micromax'
     model_replacement: '$1$2'
-  - regex: '; *Micromax[ _](A\d{2,3}[^;/]*) Build'
+  - regex: '; {0,2}Micromax[ _](A\d{2,3}[^;/]*) Build'
     regex_flag: 'i'
     device_replacement: 'Micromax $1'
     brand_replacement: 'Micromax'
     model_replacement: '$1'
   # be carefull here with Acer e.g. A500
-  - regex: '; *(A\d{2}|A[12]\d{2}|A90S|A110Q) Build'
+  - regex: '; {0,2}(A\d{2}|A[12]\d{2}|A90S|A110Q) Build'
     regex_flag: 'i'
     device_replacement: 'Micromax $1'
     brand_replacement: 'Micromax'
     model_replacement: '$1'
-  - regex: '; *Micromax[ _](P\d{3}[^;/]*) Build'
+  - regex: '; {0,2}Micromax[ _](P\d{3}[^;/]*) Build'
     regex_flag: 'i'
     device_replacement: 'Micromax $1'
     brand_replacement: 'Micromax'
     model_replacement: '$1'
-  - regex: '; *(P\d{3}|P\d{3}\(Funbook\)) Build'
+  - regex: '; {0,2}(P\d{3}|P\d{3}\(Funbook\)) Build'
     regex_flag: 'i'
     device_replacement: 'Micromax $1'
     brand_replacement: 'Micromax'
@@ -3175,7 +3497,7 @@ device_parsers:
   # Mito
   # @ref: http://new.mitomobile.com/
   #########
-  - regex: '; *(MITO)[ _\-]?([^;/]+) Build'
+  - regex: '; {0,2}(MITO)[ _\-]?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Mito'
@@ -3185,7 +3507,7 @@ device_parsers:
   # Mobistel
   # @ref: http://www.mobistel.com/
   #########
-  - regex: '; *(Cynus)[ _](F5|T\d|.+?) *(?:Build|[;/\)])'
+  - regex: '; {0,2}(Cynus)[ _](F5|T\d|.{1,200}?) {0,2}(?:Build|[;/\)])'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Mobistel'
@@ -3195,12 +3517,12 @@ device_parsers:
   # Modecom
   # @ref: http://www.modecom.eu/tablets/portal/
   #########
-  - regex: '; *(MODECOM |)(FreeTab) ?([^;/]+) Build'
+  - regex: '; {0,2}(MODECOM |)(FreeTab) ?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1$2 $3'
     brand_replacement: 'Modecom'
     model_replacement: '$2 $3'
-  - regex: '; *(MODECOM )([^;/]+) Build'
+  - regex: '; {0,2}(MODECOM )([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Modecom'
@@ -3210,32 +3532,32 @@ device_parsers:
   # Motorola
   # @ref: http://www.motorola.com/us/shop-all-mobile-phones/
   #########
-  - regex: '; *(MZ\d{3}\+?|MZ\d{3} 4G|Xoom|XOOM[^;/]*) Build'
+  - regex: '; {0,2}(MZ\d{3}\+?|MZ\d{3} 4G|Xoom|XOOM[^;/]*) Build'
     device_replacement: 'Motorola $1'
     brand_replacement: 'Motorola'
     model_replacement: '$1'
-  - regex: '; *(Milestone )(XT[^;/]*) Build'
+  - regex: '; {0,2}(Milestone )(XT[^;/]*) Build'
     device_replacement: 'Motorola $1$2'
     brand_replacement: 'Motorola'
     model_replacement: '$2'
-  - regex: '; *(Motoroi ?x|Droid X|DROIDX) Build'
+  - regex: '; {0,2}(Motoroi ?x|Droid X|DROIDX) Build'
     regex_flag: 'i'
     device_replacement: 'Motorola $1'
     brand_replacement: 'Motorola'
     model_replacement: 'DROID X'
-  - regex: '; *(Droid[^;/]*|DROID[^;/]*|Milestone[^;/]*|Photon|Triumph|Devour|Titanium) Build'
+  - regex: '; {0,2}(Droid[^;/]*|DROID[^;/]*|Milestone[^;/]*|Photon|Triumph|Devour|Titanium) Build'
     device_replacement: 'Motorola $1'
     brand_replacement: 'Motorola'
     model_replacement: '$1'
-  - regex: '; *(A555|A85[34][^;/]*|A95[356]|ME[58]\d{2}\+?|ME600|ME632|ME722|MB\d{3}\+?|MT680|MT710|MT870|MT887|MT917|WX435|WX453|WX44[25]|XT\d{3,4}[A-Z\+]*|CL[iI]Q|CL[iI]Q XT) Build'
+  - regex: '; {0,2}(A555|A85[34][^;/]*|A95[356]|ME[58]\d{2}\+?|ME600|ME632|ME722|MB\d{3}\+?|MT680|MT710|MT870|MT887|MT917|WX435|WX453|WX44[25]|XT\d{3,4}[A-Z\+]*|CL[iI]Q|CL[iI]Q XT) Build'
     device_replacement: '$1'
     brand_replacement: 'Motorola'
     model_replacement: '$1'
-  - regex: '; *(Motorola MOT-|Motorola[ _\-]|MOT\-?)([^;/]+) Build'
+  - regex: '; {0,2}(Motorola MOT-|Motorola[ _\-]|MOT\-?)([^;/]{1,100}) Build'
     device_replacement: '$1$2'
     brand_replacement: 'Motorola'
     model_replacement: '$2'
-  - regex: '; *(Moto[_ ]?|MOT\-)([^;/]+) Build'
+  - regex: '; {0,2}(Moto[_ ]?|MOT\-)([^;/]{1,100}) Build'
     device_replacement: '$1$2'
     brand_replacement: 'Motorola'
     model_replacement: '$2'
@@ -3244,7 +3566,7 @@ device_parsers:
   # MpMan
   # @ref: http://www.mpmaneurope.com
   #########
-  - regex: '; *((?:MP[DQ]C|MPG\d{1,4}|MP\d{3,4}|MID(?:(?:10[234]|114|43|7[247]|8[24]|7)C|8[01]1))[^;/]*) Build'
+  - regex: '; {0,2}((?:MP[DQ]C|MPG\d{1,4}|MP\d{3,4}|MID(?:(?:10[234]|114|43|7[247]|8[24]|7)C|8[01]1))[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Mpman'
     model_replacement: '$1'
@@ -3253,7 +3575,7 @@ device_parsers:
   # MSI
   # @ref: http://www.msi.com/product/windpad/
   #########
-  - regex: '; *(?:MSI[ _]|)(Primo\d+|Enjoy[ _\-][^;/]+) Build'
+  - regex: '; {0,2}(?:MSI[ _]|)(Primo\d+|Enjoy[ _\-][^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'Msi'
@@ -3263,7 +3585,7 @@ device_parsers:
   # Multilaser
   # http://www.multilaser.com.br/listagem_produtos.php?cat=5
   #########
-  - regex: '; *Multilaser[ _]([^;/]+) Build'
+  - regex: '; {0,2}Multilaser[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Multilaser'
     model_replacement: '$1'
@@ -3272,15 +3594,15 @@ device_parsers:
   # MyPhone
   # @ref: http://myphone.com.ph/
   #########
-  - regex: '; *(My)[_]?(Pad)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(My)[_]?(Pad)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2 $3'
     brand_replacement: 'MyPhone'
     model_replacement: '$1$2 $3'
-  - regex: '; *(My)\|?(Phone)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(My)\|?(Phone)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2 $3'
     brand_replacement: 'MyPhone'
     model_replacement: '$3'
-  - regex: '; *(A\d+)[ _](Duo|) Build'
+  - regex: '; {0,2}(A\d+)[ _](Duo|)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'MyPhone'
@@ -3290,7 +3612,7 @@ device_parsers:
   # Mytab
   # @ref: http://www.mytab.eu/en/category/mytab-products/
   #########
-  - regex: '; *(myTab[^;/]*) Build'
+  - regex: '; {0,2}(myTab[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Mytab'
     model_replacement: '$1'
@@ -3299,7 +3621,7 @@ device_parsers:
   # Nabi
   # @ref: https://www.nabitablet.com
   #########
-  - regex: '; *(NABI2?-)([^;/]+) Build/'
+  - regex: '; {0,2}(NABI2?-)([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Nabi'
     model_replacement: '$2'
@@ -3308,15 +3630,15 @@ device_parsers:
   # Nec Medias
   # @ref: http://www.n-keitai.com/
   #########
-  - regex: '; *(N-\d+[CDE]) Build/'
+  - regex: '; {0,2}(N-\d+[CDE])(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Nec'
     model_replacement: '$1'
-  - regex: '; ?(NEC-)(.*) Build/'
+  - regex: '; ?(NEC-)(.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Nec'
     model_replacement: '$2'
-  - regex: '; *(LT-NA7) Build/'
+  - regex: '; {0,2}(LT-NA7)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Nec'
     model_replacement: 'Lifetouch Note'
@@ -3325,7 +3647,7 @@ device_parsers:
   # Nextbook
   # @ref: http://nextbookusa.com
   #########
-  - regex: '; *(NXM\d+[A-z0-9_]*|Next\d[A-z0-9_ \-]*|NEXT\d[A-z0-9_ \-]*|Nextbook [A-z0-9_ ]*|DATAM803HC|M805)(?: Build|[\);])'
+  - regex: '; {0,2}(NXM\d+[A-Za-z0-9_]{0,50}|Next\d[A-Za-z0-9_ \-]{0,50}|NEXT\d[A-Za-z0-9_ \-]{0,50}|Nextbook [A-Za-z0-9_ ]{0,50}|DATAM803HC|M805)(?: Build|[\);])'
     device_replacement: '$1'
     brand_replacement: 'Nextbook'
     model_replacement: '$1'
@@ -3334,22 +3656,26 @@ device_parsers:
   # Nokia
   # @ref: http://www.nokia.com
   #########
-  - regex: '; *(Nokia)([ _\-]*)([^;/]*) Build'
+  - regex: '; {0,2}(Nokia)([ _\-]{0,5})([^;/]{0,50}) Build'
     regex_flag: 'i'
     device_replacement: '$1$2$3'
     brand_replacement: 'Nokia'
     model_replacement: '$3'
+  - regex: '; {0,2}(TA\-\d{4})(?: Build|\) AppleWebKit)'
+    device_replacement: 'Nokia $1'
+    brand_replacement: 'Nokia'
+    model_replacement: '$1'
 
   #########
   # Nook
   # @ref:
   # TODO nook browser/1.0
   #########
-  - regex: '; *(Nook ?|Barnes & Noble Nook |BN )([^;/]+) Build'
+  - regex: '; {0,2}(Nook ?|Barnes & Noble Nook |BN )([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Nook'
     model_replacement: '$2'
-  - regex: '; *(NOOK |)(BNRV200|BNRV200A|BNTV250|BNTV250A|BNTV400|BNTV600|LogicPD Zoom2) Build'
+  - regex: '; {0,2}(NOOK |)(BNRV200|BNRV200A|BNTV250|BNTV250A|BNTV400|BNTV600|LogicPD Zoom2)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Nook'
     model_replacement: '$2'
@@ -3362,7 +3688,7 @@ device_parsers:
   # Olivetti
   # @ref: http://www.olivetti.de/EN/Page/t02/view_html?idp=348
   #########
-  - regex: '; *(OP110|OliPad[^;/]+) Build'
+  - regex: '; {0,2}(OP110|OliPad[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Olivetti $1'
     brand_replacement: 'Olivetti'
     model_replacement: '$1'
@@ -3373,7 +3699,7 @@ device_parsers:
   # @note: MID tablets might get matched by CobyKyros first
   # @models: (T107|MID(?:700[2-5]|7031|7108|7132|750[02]|8001|8500|9001|971[12])
   #########
-  - regex: '; *OMEGA[ _\-](MID[^;/]+) Build'
+  - regex: '; {0,2}OMEGA[ _\-](MID[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Omega $1'
     brand_replacement: 'Omega'
     model_replacement: '$1'
@@ -3386,7 +3712,7 @@ device_parsers:
   # OpenPeak
   # @ref: https://support.google.com/googleplay/answer/1727131?hl=en
   #########
-  - regex: '; *((?:CIUS|cius)[^;/]*) Build'
+  - regex: '; {0,2}((?:CIUS|cius)[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: 'Openpeak $1'
     brand_replacement: 'Openpeak'
     model_replacement: '$1'
@@ -3395,12 +3721,19 @@ device_parsers:
   # Oppo
   # @ref: http://en.oppo.com/products/
   #########
-  - regex: '; *(Find ?(?:5|7a)|R8[012]\d{1,2}|T703\d{0,1}|U70\d{1,2}T?|X90\d{1,2}) Build'
+  - regex: '; {0,2}(Find ?(?:5|7a)|R8[012]\d{1,2}|T703\d?|U70\d{1,2}T?|X90\d{1,2}|[AFR]\d{1,2}[a-z]{1,2})(?: Build|\) AppleWebKit)'
     device_replacement: 'Oppo $1'
     brand_replacement: 'Oppo'
     model_replacement: '$1'
-  - regex: '; *OPPO ?([^;/]+) Build/'
+  - regex: '; {0,2}OPPO ?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Oppo $1'
+    brand_replacement: 'Oppo'
+    model_replacement: '$1'
+  - regex: '; {0,2}(CPH\d{1,4}|RMX\d{1,4}|P[A-Z]{3}\d{2})(?: Build|\) AppleWebKit)'
+    device_replacement: 'Oppo $1'
+    brand_replacement: 'Oppo'
+  - regex: '; {0,2}(A1601)(?: Build|\) AppleWebKit)'
+    device_replacement: 'Oppo F1s'
     brand_replacement: 'Oppo'
     model_replacement: '$1'
 
@@ -3408,20 +3741,20 @@ device_parsers:
   # Odys
   # @ref: http://odys.de
   #########
-  - regex: '; *(?:Odys\-|ODYS\-|ODYS )([^;/]+) Build'
+  - regex: '; {0,2}(?:Odys\-|ODYS\-|ODYS )([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Odys $1'
     brand_replacement: 'Odys'
     model_replacement: '$1'
-  - regex: '; *(SELECT) ?(7) Build'
+  - regex: '; {0,2}(SELECT) ?(7)(?: Build|\) AppleWebKit)'
     device_replacement: 'Odys $1 $2'
     brand_replacement: 'Odys'
     model_replacement: '$1 $2'
-  - regex: '; *(PEDI)_(PLUS)_(W) Build'
+  - regex: '; {0,2}(PEDI)_(PLUS)_(W)(?: Build|\) AppleWebKit)'
     device_replacement: 'Odys $1 $2 $3'
     brand_replacement: 'Odys'
     model_replacement: '$1 $2 $3'
   # Weltbild - Tablet PC 4 = Cat Phoenix = Odys Tablet PC 4?
-  - regex: '; *(AEON|BRAVIO|FUSION|FUSION2IN1|Genio|EOS10|IEOS[^;/]*|IRON|Loox|LOOX|LOOX Plus|Motion|NOON|NOON_PRO|NEXT|OPOS|PEDI[^;/]*|PRIME[^;/]*|STUDYTAB|TABLO|Tablet-PC-4|UNO_X8|XELIO[^;/]*|Xelio ?\d+ ?[Pp]ro|XENO10|XPRESS PRO) Build'
+  - regex: '; {0,2}(AEON|BRAVIO|FUSION|FUSION2IN1|Genio|EOS10|IEOS[^;/]*|IRON|Loox|LOOX|LOOX Plus|Motion|NOON|NOON_PRO|NEXT|OPOS|PEDI[^;/]*|PRIME[^;/]*|STUDYTAB|TABLO|Tablet-PC-4|UNO_X8|XELIO[^;/]*|Xelio ?\d+ ?[Pp]ro|XENO10|XPRESS PRO)(?: Build|\) AppleWebKit)'
     device_replacement: 'Odys $1'
     brand_replacement: 'Odys'
     model_replacement: '$1'
@@ -3430,11 +3763,11 @@ device_parsers:
   # OnePlus
   # @ref https://oneplus.net/
   #########
-  - regex: '; (ONE [a-zA-Z]\d+) Build/'
+  - regex: '; (ONE [a-zA-Z]\d+)(?: Build|\) AppleWebKit)'
     device_replacement: 'OnePlus $1'
     brand_replacement: 'OnePlus'
     model_replacement: '$1'
-  - regex: '; (ONEPLUS [a-zA-Z]\d+) Build/'
+  - regex: '; (ONEPLUS [a-zA-Z]\d+)(?: Build|\) AppleWebKit)'
     device_replacement: 'OnePlus $1'
     brand_replacement: 'OnePlus'
     model_replacement: '$1'
@@ -3443,7 +3776,7 @@ device_parsers:
   # Orion
   # @ref: http://www.orion.ua/en/products/computer-products/tablet-pcs.html
   #########
-  - regex: '; *(TP-\d+) Build/'
+  - regex: '; {0,2}(TP-\d+)(?: Build|\) AppleWebKit)'
     device_replacement: 'Orion $1'
     brand_replacement: 'Orion'
     model_replacement: '$1'
@@ -3452,7 +3785,7 @@ device_parsers:
   # PackardBell
   # @ref: http://www.packardbell.com/pb/en/AE/content/productgroup/tablets
   #########
-  - regex: '; *(G100W?) Build/'
+  - regex: '; {0,2}(G100W?)(?: Build|\) AppleWebKit)'
     device_replacement: 'PackardBell $1'
     brand_replacement: 'PackardBell'
     model_replacement: '$1'
@@ -3463,17 +3796,17 @@ device_parsers:
   # @models: T11, T21, T31, P11, P51, Eluga Power, Eluga DL1
   # @models: (tab) Toughpad FZ-A1, Toughpad JT-B1
   #########
-  - regex: '; *(Panasonic)[_ ]([^;/]+) Build'
+  - regex: '; {0,2}(Panasonic)[_ ]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
   # Toughpad
-  - regex: '; *(FZ-A1B|JT-B1) Build'
+  - regex: '; {0,2}(FZ-A1B|JT-B1)(?: Build|\) AppleWebKit)'
     device_replacement: 'Panasonic $1'
     brand_replacement: 'Panasonic'
     model_replacement: '$1'
   # Eluga Power
-  - regex: '; *(dL1|DL1) Build'
+  - regex: '; {0,2}(dL1|DL1)(?: Build|\) AppleWebKit)'
     device_replacement: 'Panasonic $1'
     brand_replacement: 'Panasonic'
     model_replacement: '$1'
@@ -3484,15 +3817,15 @@ device_parsers:
   # @href: http://www.pantech.co.kr/en/prod/prodList.do?gbrand=VEGA
   # @models: ADR8995, ADR910L, ADR930VW, C790, CDM8992, CDM8999, IS06, IS11PT, P2000, P2020, P2030, P4100, P5000, P6010, P6020, P6030, P7000, P7040, P8000, P8010, P9020, P9050, P9060, P9070, P9090, PT001, PT002, PT003, TXT8040, TXT8045, VEGA PTL21
   #########
-  - regex: '; *(SKY[ _]|)(IM\-[AT]\d{3}[^;/]+).* Build/'
+  - regex: '; {0,2}(SKY[ _]|)(IM\-[AT]\d{3}[^;/]{1,100}).{0,30} Build/'
     device_replacement: 'Pantech $1$2'
     brand_replacement: 'Pantech'
     model_replacement: '$1$2'
-  - regex: '; *((?:ADR8995|ADR910L|ADR930L|ADR930VW|PTL21|P8000)(?: 4G|)) Build/'
+  - regex: '; {0,2}((?:ADR8995|ADR910L|ADR930L|ADR930VW|PTL21|P8000)(?: 4G|)) Build/'
     device_replacement: '$1'
     brand_replacement: 'Pantech'
     model_replacement: '$1'
-  - regex: '; *Pantech([^;/]+).* Build/'
+  - regex: '; {0,2}Pantech([^;/]{1,30}).{0,200}? Build/'
     device_replacement: 'Pantech $1'
     brand_replacement: 'Pantech'
     model_replacement: '$1'
@@ -3501,7 +3834,7 @@ device_parsers:
   # Papayre
   # @ref: http://grammata.es/
   #########
-  - regex: '; *(papyre)[ _\-]([^;/]+) Build/'
+  - regex: '; {0,2}(papyre)[ _\-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Papyre'
@@ -3511,7 +3844,7 @@ device_parsers:
   # Pearl
   # @ref: http://www.pearl.de/c-1540.shtml
   #########
-  - regex: '; *(?:Touchlet )?(X10\.[^;/]+) Build/'
+  - regex: '; {0,2}(?:Touchlet )?(X10\.[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Pearl $1'
     brand_replacement: 'Pearl'
     model_replacement: '$1'
@@ -3520,15 +3853,15 @@ device_parsers:
   # Phicomm
   # @ref: http://www.phicomm.com.cn/
   #########
-  - regex: '; PHICOMM (i800) Build/'
+  - regex: '; PHICOMM (i800)(?: Build|\) AppleWebKit)'
     device_replacement: 'Phicomm $1'
     brand_replacement: 'Phicomm'
     model_replacement: '$1'
-  - regex: '; PHICOMM ([^;/]+) Build/'
+  - regex: '; PHICOMM ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Phicomm $1'
     brand_replacement: 'Phicomm'
     model_replacement: '$1'
-  - regex: '; *(FWS\d{3}[^;/]+) Build/'
+  - regex: '; {0,2}(FWS\d{3}[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Phicomm $1'
     brand_replacement: 'Phicomm'
     model_replacement: '$1'
@@ -3540,11 +3873,11 @@ device_parsers:
   # @ref: http://www.support.philips.com/support/catalog/products.jsp?_dyncharset=UTF-8&country=&categoryid=ENTERTAINMENT_TABLETS_SU_CN_CARE&userLanguage=en&navCount=0&groupId=&catalogType=&navAction=push&userCountry=cn&title=Entertainment+Tablets&cateId=TABLETS_CA_CN_CARE
   #########
   # @note: this a best guess according to available philips models. Need more User-Agents
-  - regex: '; *(D633|D822|D833|T539|T939|V726|W335|W336|W337|W3568|W536|W5510|W626|W632|W6350|W6360|W6500|W732|W736|W737|W7376|W820|W832|W8355|W8500|W8510|W930) Build'
+  - regex: '; {0,2}(D633|D822|D833|T539|T939|V726|W335|W336|W337|W3568|W536|W5510|W626|W632|W6350|W6360|W6500|W732|W736|W737|W7376|W820|W832|W8355|W8500|W8510|W930)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Philips'
     model_replacement: '$1'
-  - regex: '; *(?:Philips|PHILIPS)[ _]([^;/]+) Build'
+  - regex: '; {0,2}(?:Philips|PHILIPS)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Philips $1'
     brand_replacement: 'Philips'
     model_replacement: '$1'
@@ -3553,7 +3886,7 @@ device_parsers:
   # Pipo
   # @ref: http://www.pipo.cn/En/
   #########
-  - regex: 'Android 4\..*; *(M[12356789]|U[12368]|S[123])\ ?(pro)? Build'
+  - regex: 'Android 4\..{0,200}; {0,2}(M[12356789]|U[12368]|S[123])\ ?(pro)?(?: Build|\) AppleWebKit)'
     device_replacement: 'Pipo $1$2'
     brand_replacement: 'Pipo'
     model_replacement: '$1$2'
@@ -3562,7 +3895,7 @@ device_parsers:
   # Ployer
   # @ref: http://en.ployer.cn/
   #########
-  - regex: '; *(MOMO[^;/]+) Build'
+  - regex: '; {0,2}(MOMO[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Ployer'
     model_replacement: '$1'
@@ -3571,11 +3904,11 @@ device_parsers:
   # Polaroid/ Acho
   # @ref: http://polaroidstore.com/store/start.asp?category_id=382&category_id2=0&order=title&filter1=&filter2=&filter3=&view=all
   #########
-  - regex: '; *(?:Polaroid[ _]|)((?:MIDC\d{3,}|PMID\d{2,}|PTAB\d{3,})[^;/]*)(\/[^;/]*|) Build/'
+  - regex: '; {0,2}(?:Polaroid[ _]|)((?:MIDC\d{3,}|PMID\d{2,}|PTAB\d{3,})[^;/]{0,30}?)(\/[^;/]{0,30}|)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Polaroid'
     model_replacement: '$1'
-  - regex: '; *(?:Polaroid )(Tablet) Build/'
+  - regex: '; {0,2}(?:Polaroid )(Tablet)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Polaroid'
     model_replacement: '$1'
@@ -3585,7 +3918,7 @@ device_parsers:
   # @ref: http://pompmobileshop.com/
   #########
   #~ TODO
-  - regex: '; *(POMP)[ _\-](.+?) *(?:Build|[;/\)])'
+  - regex: '; {0,2}(POMP)[ _\-](.{1,200}?) {0,2}(?:Build|[;/\)])'
     device_replacement: '$1 $2'
     brand_replacement: 'Pomp'
     model_replacement: '$2'
@@ -3594,11 +3927,11 @@ device_parsers:
   # Positivo
   # @ref: http://www.positivoinformatica.com.br/www/pessoal/tablet-ypy/
   #########
-  - regex: '; *(TB07STA|TB10STA|TB07FTA|TB10FTA) Build/'
+  - regex: '; {0,2}(TB07STA|TB10STA|TB07FTA|TB10FTA)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Positivo'
     model_replacement: '$1'
-  - regex: '; *(?:Positivo |)((?:YPY|Ypy)[^;/]+) Build/'
+  - regex: '; {0,2}(?:Positivo |)((?:YPY|Ypy)[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Positivo'
     model_replacement: '$1'
@@ -3608,15 +3941,15 @@ device_parsers:
   # @ref: http://www.pointofview-online.com/default2.php
   # @TODO: Smartphone Models MOB-3515, MOB-5045-B missing
   #########
-  - regex: '; *(MOB-[^;/]+) Build/'
+  - regex: '; {0,2}(MOB-[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'POV'
     model_replacement: '$1'
-  - regex: '; *POV[ _\-]([^;/]+) Build/'
+  - regex: '; {0,2}POV[ _\-]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'POV $1'
     brand_replacement: 'POV'
     model_replacement: '$1'
-  - regex: '; *((?:TAB-PLAYTAB|TAB-PROTAB|PROTAB|PlayTabPro|Mobii[ _\-]|TAB-P)[^;/]*) Build/'
+  - regex: '; {0,2}((?:TAB-PLAYTAB|TAB-PROTAB|PROTAB|PlayTabPro|Mobii[ _\-]|TAB-P)[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: 'POV $1'
     brand_replacement: 'POV'
     model_replacement: '$1'
@@ -3626,7 +3959,7 @@ device_parsers:
   # @ref: http://www.prestigio.com/catalogue/MultiPhones
   # @ref: http://www.prestigio.com/catalogue/MultiPads
   #########
-  - regex: '; *(?:Prestigio |)((?:PAP|PMP)\d[^;/]+) Build/'
+  - regex: '; {0,2}(?:Prestigio |)((?:PAP|PMP)\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Prestigio $1'
     brand_replacement: 'Prestigio'
     model_replacement: '$1'
@@ -3635,7 +3968,7 @@ device_parsers:
   # Proscan
   # @ref: http://www.proscanvideo.com/products-search.asp?itemClass=TABLET&itemnmbr=
   #########
-  - regex: '; *(PLT[0-9]{4}.*) Build/'
+  - regex: '; {0,2}(PLT[0-9]{4}.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Proscan'
     model_replacement: '$1'
@@ -3644,15 +3977,15 @@ device_parsers:
   # QMobile
   # @ref: http://www.qmobile.com.pk/
   #########
-  - regex: '; *(A2|A5|A8|A900)_?(Classic|) Build'
+  - regex: '; {0,2}(A2|A5|A8|A900)_?(Classic|)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Qmobile'
     model_replacement: '$1 $2'
-  - regex: '; *(Q[Mm]obile)_([^_]+)_([^_]+) Build'
+  - regex: '; {0,2}(Q[Mm]obile)_([^_]+)_([^_]+?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Qmobile $2 $3'
     brand_replacement: 'Qmobile'
     model_replacement: '$2 $3'
-  - regex: '; *(Q\-?[Mm]obile)[_ ](A[^;/]+) Build'
+  - regex: '; {0,2}(Q\-?[Mm]obile)[_ ](A[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Qmobile $2'
     brand_replacement: 'Qmobile'
     model_replacement: '$2'
@@ -3661,11 +3994,11 @@ device_parsers:
   # Qmobilevn
   # @ref: http://qmobile.vn/san-pham.html
   #########
-  - regex: '; *(Q\-Smart)[ _]([^;/]+) Build/'
+  - regex: '; {0,2}(Q\-Smart)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Qmobilevn'
     model_replacement: '$2'
-  - regex: '; *(Q\-?[Mm]obile)[ _\-](S[^;/]+) Build/'
+  - regex: '; {0,2}(Q\-?[Mm]obile)[ _\-](S[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Qmobilevn'
     model_replacement: '$2'
@@ -3674,7 +4007,7 @@ device_parsers:
   # Quanta
   # @ref: ?
   #########
-  - regex: '; *(TA1013) Build'
+  - regex: '; {0,2}(TA1013)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Quanta'
     model_replacement: '$1'
@@ -3683,11 +4016,11 @@ device_parsers:
   # RCA
   # @ref: http://rcamobilephone.com/
   #########
-  - regex: '; (RCT\w+) Build/'
+  - regex: '; (RCT\w+)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'RCA'
     model_replacement: '$1'
-  - regex: '; RCA (\w+) Build/'
+  - regex: '; RCA (\w+)(?: Build|\) AppleWebKit)'
     device_replacement: 'RCA $1'
     brand_replacement: 'RCA'
     model_replacement: '$1'
@@ -3697,7 +4030,7 @@ device_parsers:
   # @ref: http://www.rock-chips.com/a/cn/product/index.html
   # @note: manufacturer sells chipsets - I assume that these UAs are dev-boards
   #########
-  - regex: '; *(RK\d+),? Build/'
+  - regex: '; {0,2}(RK\d+),?(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Rockchip'
     model_replacement: '$1'
@@ -3710,47 +4043,55 @@ device_parsers:
   # Samsung Android Devices
   # @ref: http://www.samsung.com/us/mobile/cell-phones/all-products
   #########
-  - regex: '; *(SAMSUNG |Samsung |)((?:Galaxy (?:Note II|S\d)|GT-I9082|GT-I9205|GT-N7\d{3}|SM-N9005)[^;/]*)\/?[^;/]* Build/'
+  - regex: '; {0,2}(SAMSUNG |Samsung |)((?:Galaxy (?:Note II|S\d)|GT-I9082|GT-I9205|GT-N7\d{3}|SM-N9005)[^;/]{0,100})\/?[^;/]{0,50} Build/'
     device_replacement: 'Samsung $1$2'
     brand_replacement: 'Samsung'
     model_replacement: '$2'
-  - regex: '; *(Google |)(Nexus [Ss](?: 4G|)) Build/'
+  - regex: '; {0,2}(Google |)(Nexus [Ss](?: 4G|)) Build/'
     device_replacement: 'Samsung $1$2'
     brand_replacement: 'Samsung'
     model_replacement: '$2'
-  - regex: '; *(SAMSUNG |Samsung )([^\/]*)\/[^ ]* Build/'
+  - regex: '; {0,2}(SAMSUNG |Samsung )([^\/]{0,50})\/[^ ]{0,50} Build/'
     device_replacement: 'Samsung $2'
     brand_replacement: 'Samsung'
     model_replacement: '$2'
-  - regex: '; *(Galaxy(?: Ace| Nexus| S ?II+|Nexus S| with MCR 1.2| Mini Plus 4G|)) Build/'
+  - regex: '; {0,2}(Galaxy(?: Ace| Nexus| S ?II+|Nexus S| with MCR 1.2| Mini Plus 4G|)) Build/'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
-  - regex: '; *(SAMSUNG[ _\-]|)(?:SAMSUNG[ _\-])([^;/]+) Build'
+  - regex: '; {0,2}(SAMSUNG[ _\-]|)(?:SAMSUNG[ _\-])([^;/]{1,100}) Build'
     device_replacement: 'Samsung $2'
     brand_replacement: 'Samsung'
     model_replacement: '$2'
-  - regex: '; *(SAMSUNG-|)(GT\-[BINPS]\d{4}[^\/]*)(\/[^ ]*) Build'
+  - regex: '; {0,2}(SAMSUNG-|)(GT\-[BINPS]\d{4}[^\/]{0,50})(\/[^ ]{0,50}) Build'
     device_replacement: 'Samsung $1$2$3'
     brand_replacement: 'Samsung'
     model_replacement: '$2'
-  - regex: '(?:; *|^)((?:GT\-[BIiNPS]\d{4}|I9\d{2}0[A-Za-z\+]?\b)[^;/\)]*?)(?:Build|Linux|MIUI|[;/\)])'
+  - regex: '(?:; {0,2}|^)((?:GT\-[BIiNPS]\d{4}|I9\d{2}0[A-Za-z\+]?\b)[^;/\)]*?)(?:Build|Linux|MIUI|[;/\)])'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
-  - regex: '; (SAMSUNG-)([A-Za-z0-9\-]+).* Build/'
+  - regex: '; (SAMSUNG-)([A-Za-z0-9\-]{0,50}).{0,200} Build/'
     device_replacement: 'Samsung $1$2'
     brand_replacement: 'Samsung'
     model_replacement: '$2'
-  - regex: '; *((?:SCH|SGH|SHV|SHW|SPH|SC|SM)\-[A-Za-z0-9 ]+)(/?[^ ]*|) Build'
+  - regex: '; {0,2}((?:SCH|SGH|SHV|SHW|SPH|SC|SM)\-[A-Za-z0-9 ]{1,50})(/?[^ ]*|) Build'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
-  - regex: ' ((?:SCH)\-[A-Za-z0-9 ]+)(/?[^ ]*|) Build'
+  - regex: '; {0,2}((?:SC)\-[A-Za-z0-9 ]{1,50})(/?[^ ]*|)\)'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
-  - regex: '; *(Behold ?(?:2|II)|YP\-G[^;/]+|EK-GC100|SCL21|I9300) Build'
+  - regex: ' ((?:SCH)\-[A-Za-z0-9 ]{1,50})(/?[^ ]*|) Build'
+    device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  - regex: '; {0,2}(Behold ?(?:2|II)|YP\-G[^;/]{1,100}|EK-GC100|SCL21|I9300) Build'
+    device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  - regex: '; {0,2}((?:SCH|SGH|SHV|SHW|SPH|SC|SM)\-[A-Za-z0-9]{5,6})[\)]'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
@@ -3760,11 +4101,11 @@ device_parsers:
   # @ref: http://www.sharp-phone.com/en/index.html
   # @ref: http://www.android.com/devices/?country=all&m=sharp
   #########
-  - regex: '; *(SH\-?\d\d[^;/]+|SBM\d[^;/]+) Build'
+  - regex: '; {0,2}(SH\-?\d\d[^;/]{1,100}|SBM\d[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Sharp'
     model_replacement: '$1'
-  - regex: '; *(SHARP[ -])([^;/]+) Build'
+  - regex: '; {0,2}(SHARP[ -])([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Sharp'
     model_replacement: '$2'
@@ -3773,15 +4114,15 @@ device_parsers:
   # Simvalley
   # @ref: http://www.simvalley-mobile.de/
   #########
-  - regex: '; *(SPX[_\-]\d[^;/]*) Build/'
+  - regex: '; {0,2}(SPX[_\-]\d[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Simvalley'
     model_replacement: '$1'
-  - regex: '; *(SX7\-PEARL\.GmbH) Build/'
+  - regex: '; {0,2}(SX7\-PEARL\.GmbH)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Simvalley'
     model_replacement: '$1'
-  - regex: '; *(SP[T]?\-\d{2}[^;/]*) Build/'
+  - regex: '; {0,2}(SP[T]?\-\d{2}[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Simvalley'
     model_replacement: '$1'
@@ -3791,7 +4132,7 @@ device_parsers:
   # @ref: http://www.sk-w.com/phone/phone_list.jsp
   # @ref: http://www.android.com/devices/?country=all&m=sk-telesys
   #########
-  - regex: '; *(SK\-.*) Build/'
+  - regex: '; {0,2}(SK\-.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'SKtelesys'
     model_replacement: '$1'
@@ -3800,11 +4141,11 @@ device_parsers:
   # Skytex
   # @ref: http://skytex.com/android
   #########
-  - regex: '; *(?:SKYTEX|SX)-([^;/]+) Build'
+  - regex: '; {0,2}(?:SKYTEX|SX)-([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Skytex'
     model_replacement: '$1'
-  - regex: '; *(IMAGINE [^;/]+) Build'
+  - regex: '; {0,2}(IMAGINE [^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Skytex'
     model_replacement: '$1'
@@ -3814,7 +4155,7 @@ device_parsers:
   # @ref: http://en.smartdevices.com.cn/Products/
   # @models: Z8, X7, U7H, U7, T30, T20, Ten3, V5-II, T7-3G, SmartQ5, K7, S7, Q8, T19, Ten2, Ten, R10, T7, R7, V5, V7, SmartQ7
   #########
-  - regex: '; *(SmartQ) ?([^;/]+) Build/'
+  - regex: '; {0,2}(SmartQ) ?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -3824,7 +4165,7 @@ device_parsers:
   # @ref: http://www.smartbitt.com/
   # @missing: SBT Useragents
   #########
-  - regex: '; *(WF7C|WF10C|SBT[^;/]+) Build'
+  - regex: '; {0,2}(WF7C|WF10C|SBT[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Smartbitt'
     model_replacement: '$1'
@@ -3833,15 +4174,15 @@ device_parsers:
   # Softbank (Operator Branded Devices)
   # @ref: http://www.ipentec.com/document/document.aspx?page=android-useragent
   #########
-  - regex: '; *(SBM(?:003SH|005SH|006SH|007SH|102SH)) Build'
+  - regex: '; {0,2}(SBM(?:003SH|005SH|006SH|007SH|102SH)) Build'
     device_replacement: '$1'
     brand_replacement: 'Sharp'
     model_replacement: '$1'
-  - regex: '; *(003P|101P|101P11C|102P) Build'
+  - regex: '; {0,2}(003P|101P|101P11C|102P) Build'
     device_replacement: '$1'
     brand_replacement: 'Panasonic'
     model_replacement: '$1'
-  - regex: '; *(00\dZ) Build/'
+  - regex: '; {0,2}(00\dZ) Build/'
     device_replacement: '$1'
     brand_replacement: 'ZTE'
     model_replacement: '$1'
@@ -3849,11 +4190,11 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
-  - regex: '; *(001HT|X06HT) Build'
+  - regex: '; {0,2}(001HT|X06HT) Build'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
-  - regex: '; *(201M) Build'
+  - regex: '; {0,2}(201M) Build'
     device_replacement: '$1'
     brand_replacement: 'Motorola'
     model_replacement: 'XT902'
@@ -3863,11 +4204,11 @@ device_parsers:
   # @ref: http://www.trekstor.co.uk/surftabs-en.html
   # @note: Must come before SonyEricsson
   #########
-  - regex: '; *(ST\d{4}.*)Build/ST'
+  - regex: '; {0,2}(ST\d{4}.{0,200})Build/ST'
     device_replacement: 'Trekstor $1'
     brand_replacement: 'Trekstor'
     model_replacement: '$1'
-  - regex: '; *(ST\d{4}.*) Build/'
+  - regex: '; {0,2}(ST\d{4}.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Trekstor $1'
     brand_replacement: 'Trekstor'
     model_replacement: '$1'
@@ -3879,16 +4220,16 @@ device_parsers:
   # @TODO: type!
   #########
   # android matchers
-  - regex: '; *(Sony ?Ericsson ?)([^;/]+) Build'
+  - regex: '; {0,2}(Sony ?Ericsson ?)([^;/]{1,100}) Build'
     device_replacement: '$1$2'
     brand_replacement: 'SonyEricsson'
     model_replacement: '$2'
-  - regex: '; *((?:SK|ST|E|X|LT|MK|MT|WT)\d{2}[a-z0-9]*(?:-o|)|R800i|U20i) Build'
+  - regex: '; {0,2}((?:SK|ST|E|X|LT|MK|MT|WT)\d{2}[a-z0-9]*(?:-o|)|R800i|U20i) Build'
     device_replacement: '$1'
     brand_replacement: 'SonyEricsson'
     model_replacement: '$1'
   # TODO X\d+ is wrong
-  - regex: '; *(Xperia (?:A8|Arc|Acro|Active|Live with Walkman|Mini|Neo|Play|Pro|Ray|X\d+)[^;/]*) Build'
+  - regex: '; {0,2}(Xperia (?:A8|Arc|Acro|Active|Live with Walkman|Mini|Neo|Play|Pro|Ray|X\d+)[^;/]{0,50}) Build'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'SonyEricsson'
@@ -3900,31 +4241,31 @@ device_parsers:
   # @ref: http://www.sonymobile.com/global-en/products/phones/
   # @ref: http://www.sony.jp/tablet/
   #########
-  - regex: '; Sony (Tablet[^;/]+) Build'
+  - regex: '; Sony (Tablet[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Sony $1'
     brand_replacement: 'Sony'
     model_replacement: '$1'
-  - regex: '; Sony ([^;/]+) Build'
+  - regex: '; Sony ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Sony $1'
     brand_replacement: 'Sony'
     model_replacement: '$1'
-  - regex: '; *(Sony)([A-Za-z0-9\-]+) Build'
+  - regex: '; {0,2}(Sony)([A-Za-z0-9\-]+)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
-  - regex: '; *(Xperia [^;/]+) Build'
+  - regex: '; {0,2}(Xperia [^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Sony'
     model_replacement: '$1'
-  - regex: '; *(C(?:1[0-9]|2[0-9]|53|55|6[0-9])[0-9]{2}|D[25]\d{3}|D6[56]\d{2}) Build'
+  - regex: '; {0,2}(C(?:1[0-9]|2[0-9]|53|55|6[0-9])[0-9]{2}|D[25]\d{3}|D6[56]\d{2})(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Sony'
     model_replacement: '$1'
-  - regex: '; *(SGP\d{3}|SGPT\d{2}) Build'
+  - regex: '; {0,2}(SGP\d{3}|SGPT\d{2})(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Sony'
     model_replacement: '$1'
-  - regex: '; *(NW-Z1000Series) Build'
+  - regex: '; {0,2}(NW-Z1000Series)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Sony'
     model_replacement: '$1'
@@ -3947,7 +4288,7 @@ device_parsers:
   # Spice
   # @ref: http://www.spicemobilephones.co.in/
   #########
-  - regex: '; *((?:CSL_Spice|Spice|SPICE|CSL)[ _\-]?|)([Mm][Ii])([ _\-]|)(\d{3}[^;/]*) Build/'
+  - regex: '; {0,2}((?:CSL_Spice|Spice|SPICE|CSL)[ _\-]?|)([Mm][Ii])([ _\-]|)(\d{3}[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2$3$4'
     brand_replacement: 'Spice'
     model_replacement: 'Mi$4'
@@ -3956,7 +4297,7 @@ device_parsers:
   # Sprint (Operator Branded Devices)
   # @ref:
   #########
-  - regex: '; *(Sprint )(.+?) *(?:Build|[;/])'
+  - regex: '; {0,2}(Sprint )(.{1,200}?) {0,2}(?:Build|[;/])'
     device_replacement: '$1$2'
     brand_replacement: 'Sprint'
     model_replacement: '$2'
@@ -3969,7 +4310,7 @@ device_parsers:
   # Tagi
   # @ref: ??
   #########
-  - regex: '; *(TAGI[ ]?)(MID) ?([^;/]+) Build/'
+  - regex: '; {0,2}(TAGI[ ]?)(MID) ?([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2$3'
     brand_replacement: 'Tagi'
     model_replacement: '$2$3'
@@ -3978,7 +4319,7 @@ device_parsers:
   # Tecmobile
   # @ref: http://www.tecmobile.com/
   #########
-  - regex: '; *(Oyster500|Opal 800) Build'
+  - regex: '; {0,2}(Oyster500|Opal 800)(?: Build|\) AppleWebKit)'
     device_replacement: 'Tecmobile $1'
     brand_replacement: 'Tecmobile'
     model_replacement: '$1'
@@ -3987,7 +4328,7 @@ device_parsers:
   # Tecno
   # @ref: www.tecno-mobile.com/‎
   #########
-  - regex: '; *(TECNO[ _])([^;/]+) Build/'
+  - regex: '; {0,2}(TECNO[ _])([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Tecno'
     model_replacement: '$2'
@@ -3996,7 +4337,7 @@ device_parsers:
   # Telechips, Techvision evaluation boards
   # @ref:
   #########
-  - regex: '; *Android for (Telechips|Techvision) ([^ ]+) '
+  - regex: '; {0,2}Android for (Telechips|Techvision) ([^ ]+) '
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
@@ -4007,7 +4348,7 @@ device_parsers:
   # @ref: http://www.telstra.com.au/home-phone/thub-2/
   # @ref: https://support.google.com/googleplay/answer/1727131?hl=en
   #########
-  - regex: '; *(T-Hub2) Build/'
+  - regex: '; {0,2}(T-Hub2)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Telstra'
     model_replacement: '$1'
@@ -4016,7 +4357,7 @@ device_parsers:
   # Terra
   # @ref: http://www.wortmann.de/
   #########
-  - regex: '; *(PAD) ?(100[12]) Build/'
+  - regex: '; {0,2}(PAD) ?(100[12])(?: Build|\) AppleWebKit)'
     device_replacement: 'Terra $1$2'
     brand_replacement: 'Terra'
     model_replacement: '$1$2'
@@ -4025,7 +4366,7 @@ device_parsers:
   # Texet
   # @ref: http://www.texet.ru/tablet/
   #########
-  - regex: '; *(T[BM]-\d{3}[^;/]+) Build/'
+  - regex: '; {0,2}(T[BM]-\d{3}[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Texet'
     model_replacement: '$1'
@@ -4034,11 +4375,11 @@ device_parsers:
   # Thalia
   # @ref: http://www.thalia.de/shop/tolino-shine-ereader/show/
   #########
-  - regex: '; *(tolino [^;/]+) Build'
+  - regex: '; {0,2}(tolino [^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Thalia'
     model_replacement: '$1'
-  - regex: '; *Build/.* (TOLINO_BROWSER)'
+  - regex: '; {0,2}Build/.{0,200} (TOLINO_BROWSER)'
     device_replacement: '$1'
     brand_replacement: 'Thalia'
     model_replacement: 'Tolino Shine'
@@ -4048,11 +4389,11 @@ device_parsers:
   # @ref: http://en.thl.com.cn/Mobile
   # @ref: http://thlmobilestore.com
   #########
-  - regex: '; *(?:CJ[ -])?(ThL|THL)[ -]([^;/]+) Build/'
+  - regex: '; {0,2}(?:CJ[ -])?(ThL|THL)[ -]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Thl'
     model_replacement: '$2'
-  - regex: '; *(T100|T200|T5|W100|W200|W8s) Build/'
+  - regex: '; {0,2}(T100|T200|T5|W100|W200|W8s)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Thl'
     model_replacement: '$1'
@@ -4061,28 +4402,28 @@ device_parsers:
   # T-Mobile (Operator Branded Devices)
   #########
   # @ref: https://en.wikipedia.org/wiki/HTC_Hero
-  - regex: '; *(T-Mobile[ _]G2[ _]Touch) Build'
+  - regex: '; {0,2}(T-Mobile[ _]G2[ _]Touch) Build'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'Hero'
   # @ref: https://en.wikipedia.org/wiki/HTC_Desire_Z
-  - regex: '; *(T-Mobile[ _]G2) Build'
+  - regex: '; {0,2}(T-Mobile[ _]G2) Build'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'Desire Z'
-  - regex: '; *(T-Mobile myTouch Q) Build'
+  - regex: '; {0,2}(T-Mobile myTouch Q) Build'
     device_replacement: '$1'
     brand_replacement: 'Huawei'
     model_replacement: 'U8730'
-  - regex: '; *(T-Mobile myTouch) Build'
+  - regex: '; {0,2}(T-Mobile myTouch) Build'
     device_replacement: '$1'
     brand_replacement: 'Huawei'
     model_replacement: 'U8680'
-  - regex: '; *(T-Mobile_Espresso) Build'
+  - regex: '; {0,2}(T-Mobile_Espresso) Build'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'Espresso'
-  - regex: '; *(T-Mobile G1) Build'
+  - regex: '; {0,2}(T-Mobile G1) Build'
     device_replacement: '$1'
     brand_replacement: 'HTC'
     model_replacement: 'Dream'
@@ -4090,11 +4431,11 @@ device_parsers:
     device_replacement: '$1$2 $3 $4'
     brand_replacement: 'HTC'
     model_replacement: '$2 $3 $4'
-  - regex: '\b(T-Mobile)_([^_]+)_(.*) Build'
+  - regex: '\b(T-Mobile)_([^_]+)_(.{0,200}) Build'
     device_replacement: '$1 $2 $3'
     brand_replacement: 'Tmobile'
     model_replacement: '$2 $3'
-  - regex: '\b(T-Mobile)[_ ]?(.*?)Build'
+  - regex: '\b(T-Mobile)[_ ]?(.{0,200}?)Build'
     device_replacement: '$1 $2'
     brand_replacement: 'Tmobile'
     model_replacement: '$2'
@@ -4103,7 +4444,7 @@ device_parsers:
   # Tomtec
   # @ref: http://www.tom-tec.eu/pages/tablets.php
   #########
-  - regex: ' (ATP[0-9]{4}) Build'
+  - regex: ' (ATP[0-9]{4})(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Tomtec'
     model_replacement: '$1'
@@ -4112,7 +4453,7 @@ device_parsers:
   # Tooky
   # @ref: http://www.tookymobile.com/
   #########
-  - regex: ' *(TOOKY)[ _\-]([^;/]+) ?(?:Build|;)'
+  - regex: ' ?(TOOKY)[ _\-]([^;/]{1,100}) ?(?:Build|;)'
     regex_flag: 'i'
     device_replacement: '$1 $2'
     brand_replacement: 'Tooky'
@@ -4127,11 +4468,11 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'Toshiba'
     model_replacement: 'Folio 100'
-  - regex: '; *([Ff]olio ?100) Build/'
+  - regex: '; {0,2}([Ff]olio ?100)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Toshiba'
     model_replacement: 'Folio 100'
-  - regex: '; *(AT[0-9]{2,3}(?:\-A|LE\-A|PE\-A|SE|a|)|AT7-A|AT1S0|Hikari-iFrame/WDPF-[^;/]+|THRiVE|Thrive) Build/'
+  - regex: '; {0,2}(AT[0-9]{2,3}(?:\-A|LE\-A|PE\-A|SE|a|)|AT7-A|AT1S0|Hikari-iFrame/WDPF-[^;/]{1,100}|THRiVE|Thrive)(?: Build|\) AppleWebKit)'
     device_replacement: 'Toshiba $1'
     brand_replacement: 'Toshiba'
     model_replacement: '$1'
@@ -4140,12 +4481,12 @@ device_parsers:
   # Touchmate
   # @ref: http://touchmatepc.com/new/
   #########
-  - regex: '; *(TM-MID\d+[^;/]+|TOUCHMATE|MID-750) Build'
+  - regex: '; {0,2}(TM-MID\d+[^;/]{1,50}|TOUCHMATE|MID-750)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Touchmate'
     model_replacement: '$1'
   # @todo: needs verification user-agents missing
-  - regex: '; *(TM-SM\d+[^;/]+) Build'
+  - regex: '; {0,2}(TM-SM\d+[^;/]{1,50}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Touchmate'
     model_replacement: '$1'
@@ -4154,11 +4495,11 @@ device_parsers:
   # Treq
   # @ref: http://www.treq.co.id/product
   #########
-  - regex: '; *(A10 [Bb]asic2?) Build/'
+  - regex: '; {0,2}(A10 [Bb]asic2?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Treq'
     model_replacement: '$1'
-  - regex: '; *(TREQ[ _\-])([^;/]+) Build'
+  - regex: '; {0,2}(TREQ[ _\-])([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1$2'
     brand_replacement: 'Treq'
@@ -4170,21 +4511,40 @@ device_parsers:
   # @models: A936|A603|X-5|X-3
   #########
   # @todo: guessed markers
-  - regex: '; *(X-?5|X-?3) Build/'
+  - regex: '; {0,2}(X-?5|X-?3)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Umeox'
     model_replacement: '$1'
   # @todo: guessed markers
-  - regex: '; *(A502\+?|A936|A603|X1|X2) Build/'
+  - regex: '; {0,2}(A502\+?|A936|A603|X1|X2)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Umeox'
     model_replacement: '$1'
 
   #########
+  # Vernee
+  # @ref: http://vernee.cc/
+  # @models: Thor - Thor E
+  #########
+  - regex: '; thor Build/'
+    device_replacement: 'Thor'
+    brand_replacement: 'Vernee'
+    model_replacement: 'Thor'
+  # Regex to modidy for Thor Plus (don't find example UA)
+  - regex: '; Thor (E)? Build/'
+    device_replacement: 'Thor $1'
+    brand_replacement: 'Vernee'
+    model_replacement: 'Thor'
+  - regex: '; Apollo Lite Build/'
+    device_replacement: 'Apollo Lite'
+    brand_replacement: 'Vernee'
+    model_replacement: 'Apollo'
+
+  #########
   # Versus
   # @ref: http://versusuk.com/support.html
   #########
-  - regex: '(TOUCH(?:TAB|PAD).+?) Build/'
+  - regex: '(TOUCH(?:TAB|PAD).{1,200}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Versus $1'
     brand_replacement: 'Versus'
@@ -4194,7 +4554,7 @@ device_parsers:
   # Vertu
   # @ref: http://www.vertu.com/
   #########
-  - regex: '(VERTU) ([^;/]+) Build/'
+  - regex: '(VERTU) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'Vertu'
     model_replacement: '$2'
@@ -4203,11 +4563,11 @@ device_parsers:
   # Videocon
   # @ref: http://www.videoconmobiles.com
   #########
-  - regex: '; *(Videocon)[ _\-]([^;/]+) *(?:Build|;)'
+  - regex: '; {0,2}(Videocon)[ _\-]([^;/]{1,100}?) {0,2}(?:Build|;)'
     device_replacement: '$1 $2'
     brand_replacement: 'Videocon'
     model_replacement: '$2'
-  - regex: ' (VT\d{2}[A-Za-z]*) Build'
+  - regex: ' (VT\d{2}[A-Za-z]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Videocon'
     model_replacement: '$1'
@@ -4216,15 +4576,15 @@ device_parsers:
   # Viewsonic
   # @ref: http://viewsonic.com
   #########
-  - regex: '; *((?:ViewPad|ViewPhone|VSD)[^;/]+) Build/'
+  - regex: '; {0,2}((?:ViewPad|ViewPhone|VSD)[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Viewsonic'
     model_replacement: '$1'
-  - regex: '; *(ViewSonic-)([^;/]+) Build/'
+  - regex: '; {0,2}(ViewSonic-)([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'Viewsonic'
     model_replacement: '$2'
-  - regex: '; *(GTablet.*) Build/'
+  - regex: '; {0,2}(GTablet.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Viewsonic'
     model_replacement: '$1'
@@ -4233,7 +4593,7 @@ device_parsers:
   # vivo
   # @ref: http://vivo.cn/
   #########
-  - regex: '; *([Vv]ivo)[ _]([^;/]+) Build'
+  - regex: '; {0,2}([Vv]ivo)[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'vivo'
     model_replacement: '$2'
@@ -4242,7 +4602,7 @@ device_parsers:
   # Vodafone (Operator Branded Devices)
   # @ref: ??
   #########
-  - regex: '(Vodafone) (.*) Build/'
+  - regex: '(Vodafone) (.{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -4251,7 +4611,7 @@ device_parsers:
   # Walton
   # @ref: http://www.waltonbd.com/
   #########
-  - regex: '; *(?:Walton[ _\-]|)(Primo[ _\-][^;/]+) Build'
+  - regex: '; {0,2}(?:Walton[ _\-]|)(Primo[ _\-][^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Walton $1'
     brand_replacement: 'Walton'
@@ -4261,7 +4621,7 @@ device_parsers:
   # Wiko
   # @ref: http://fr.wikomobile.com/collection.php?s=Smartphones
   #########
-  - regex: '; *(?:WIKO[ \-]|)(CINK\+?|BARRY|BLOOM|DARKFULL|DARKMOON|DARKNIGHT|DARKSIDE|FIZZ|HIGHWAY|IGGY|OZZY|RAINBOW|STAIRWAY|SUBLIM|WAX|CINK [^;/]+) Build/'
+  - regex: '; {0,2}(?:WIKO[ \-]|)(CINK\+?|BARRY|BLOOM|DARKFULL|DARKMOON|DARKNIGHT|DARKSIDE|FIZZ|HIGHWAY|IGGY|OZZY|RAINBOW|STAIRWAY|SUBLIM|WAX|CINK [^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Wiko $1'
     brand_replacement: 'Wiko'
@@ -4271,7 +4631,7 @@ device_parsers:
   # WellcoM
   # @ref: ??
   #########
-  - regex: '; *WellcoM-([^;/]+) Build'
+  - regex: '; {0,2}WellcoM-([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Wellcom $1'
     brand_replacement: 'Wellcom'
     model_replacement: '$1'
@@ -4289,7 +4649,7 @@ device_parsers:
   # Wolfgang
   # @ref: http://wolfgangmobile.com/
   #########
-  - regex: '; *(AT-AS[^;/]+) Build'
+  - regex: '; {0,2}(AT-AS[^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Wolfgang $1'
     brand_replacement: 'Wolfgang'
     model_replacement: '$1'
@@ -4298,7 +4658,7 @@ device_parsers:
   # Woxter
   # @ref: http://www.woxter.es/es-es/categories/index
   #########
-  - regex: '; *(?:Woxter|Wxt) ([^;/]+) Build'
+  - regex: '; {0,2}(?:Woxter|Wxt) ([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'Woxter $1'
     brand_replacement: 'Woxter'
     model_replacement: '$1'
@@ -4307,7 +4667,7 @@ device_parsers:
   # Yarvik Zania
   # @ref: http://yarvik.com
   #########
-  - regex: '; *(?:Xenta |Luna |)(TAB[234][0-9]{2}|TAB0[78]-\d{3}|TAB0?9-\d{3}|TAB1[03]-\d{3}|SMP\d{2}-\d{3}) Build/'
+  - regex: '; {0,2}(?:Xenta |Luna |)(TAB[234][0-9]{2}|TAB0[78]-\d{3}|TAB0?9-\d{3}|TAB1[03]-\d{3}|SMP\d{2}-\d{3})(?: Build|\) AppleWebKit)'
     device_replacement: 'Yarvik $1'
     brand_replacement: 'Yarvik'
     model_replacement: '$1'
@@ -4321,7 +4681,7 @@ device_parsers:
   #   M778, M7000, M7000AD, M7000NBD, M7001, M7002, M7002KBD, M777, M767,
   #   M789, M799, M769, M757, M755, M753, M752, M739, M729, M723, M712, M727
   #########
-  - regex: '; *([A-Z]{2,4})(M\d{3,}[A-Z]{2})([^;\)\/]*)(?: Build|[;\)])'
+  - regex: '; {0,2}([A-Z]{2,4})(M\d{3,}[A-Z]{2})([^;\)\/]*)(?: Build|[;\)])'
     device_replacement: 'Yifang $1$2$3'
     brand_replacement: 'Yifang'
     model_replacement: '$2'
@@ -4330,7 +4690,19 @@ device_parsers:
   # XiaoMi
   # @ref: http://www.xiaomi.com/event/buyphone
   #########
-  - regex: '; *((Mi|MI|HM|MI-ONE|Redmi)[ -](NOTE |Note |)[^;/]*) (Build|MIUI)/'
+  - regex: '; {0,2}((Mi|MI|HM|MI-ONE|Redmi)[ -](NOTE |Note |)[^;/]*) (Build|MIUI)/'
+    device_replacement: 'XiaoMi $1'
+    brand_replacement: 'XiaoMi'
+    model_replacement: '$1'
+  - regex: '; {0,2}((Mi|MI|HM|MI-ONE|Redmi)[ -](NOTE |Note |)[^;/\)]*)'
+    device_replacement: 'XiaoMi $1'
+    brand_replacement: 'XiaoMi'
+    model_replacement: '$1'
+  - regex: '; {0,2}(MIX) (Build|MIUI)/'
+    device_replacement: 'XiaoMi $1'
+    brand_replacement: 'XiaoMi'
+    model_replacement: '$1'
+  - regex: '; {0,2}((MIX) ([^;/]*)) (Build|MIUI)/'
     device_replacement: 'XiaoMi $1'
     brand_replacement: 'XiaoMi'
     model_replacement: '$1'
@@ -4339,17 +4711,17 @@ device_parsers:
   # Xolo
   # @ref: http://www.xolo.in/
   #########
-  - regex: '; *XOLO[ _]([^;/]*tab.*) Build'
+  - regex: '; {0,2}XOLO[ _]([^;/]{0,30}tab.{0,30})(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Xolo $1'
     brand_replacement: 'Xolo'
     model_replacement: '$1'
-  - regex: '; *XOLO[ _]([^;/]+) Build'
+  - regex: '; {0,2}XOLO[ _]([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Xolo $1'
     brand_replacement: 'Xolo'
     model_replacement: '$1'
-  - regex: '; *(q\d0{2,3}[a-z]?) Build'
+  - regex: '; {0,2}(q\d0{2,3}[a-z]?)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: 'Xolo $1'
     brand_replacement: 'Xolo'
@@ -4359,7 +4731,7 @@ device_parsers:
   # Xoro
   # @ref: http://www.xoro.de/produkte/
   #########
-  - regex: '; *(PAD ?[79]\d+[^;/]*|TelePAD\d+[^;/]) Build'
+  - regex: '; {0,2}(PAD ?[79]\d+[^;/]{0,50}|TelePAD\d+[^;/])(?: Build|\) AppleWebKit)'
     device_replacement: 'Xoro $1'
     brand_replacement: 'Xoro'
     model_replacement: '$1'
@@ -4368,7 +4740,7 @@ device_parsers:
   # Zopo
   # @ref: http://www.zopomobiles.com/products.html
   #########
-  - regex: '; *(?:(?:ZOPO|Zopo)[ _]([^;/]+)|(ZP ?(?:\d{2}[^;/]+|C2))|(C[2379])) Build'
+  - regex: '; {0,2}(?:(?:ZOPO|Zopo)[ _]([^;/]{1,100}?)|(ZP ?(?:\d{2}[^;/]{1,100}|C2))|(C[2379]))(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2$3'
     brand_replacement: 'Zopo'
     model_replacement: '$1$2$3'
@@ -4377,11 +4749,11 @@ device_parsers:
   # ZiiLabs
   # @ref: http://www.ziilabs.com/products/platforms/androidreferencetablets.php
   #########
-  - regex: '; *(ZiiLABS) (Zii[^;/]*) Build'
+  - regex: '; {0,2}(ZiiLABS) (Zii[^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'ZiiLabs'
     model_replacement: '$2'
-  - regex: '; *(Zii)_([^;/]*) Build'
+  - regex: '; {0,2}(Zii)_([^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'ZiiLabs'
     model_replacement: '$2'
@@ -4390,45 +4762,45 @@ device_parsers:
   # ZTE
   # @ref: http://www.ztedevices.com/
   #########
-  - regex: '; *(ARIZONA|(?:ATLAS|Atlas) W|D930|Grand (?:[SX][^;]*|Era|Memo[^;]*)|JOE|(?:Kis|KIS)\b[^;]*|Libra|Light [^;]*|N8[056][01]|N850L|N8000|N9[15]\d{2}|N9810|NX501|Optik|(?:Vip )Racer[^;]*|RacerII|RACERII|San Francisco[^;]*|V9[AC]|V55|V881|Z[679][0-9]{2}[A-z]?) Build'
+  - regex: '; {0,2}(ARIZONA|(?:ATLAS|Atlas) W|D930|Grand (?:[SX][^;]{0,200}?|Era|Memo[^;]{0,200}?)|JOE|(?:Kis|KIS)\b[^;]{0,200}?|Libra|Light [^;]{0,200}?|N8[056][01]|N850L|N8000|N9[15]\d{2}|N9810|NX501|Optik|(?:Vip )Racer[^;]{0,200}?|RacerII|RACERII|San Francisco[^;]{0,200}?|V9[AC]|V55|V881|Z[679][0-9]{2}[A-z]?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'ZTE'
     model_replacement: '$1'
-  - regex: '; *([A-Z]\d+)_USA_[^;]* Build'
+  - regex: '; {0,2}([A-Z]\d+)_USA_[^;]{0,200}(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'ZTE'
     model_replacement: '$1'
-  - regex: '; *(SmartTab\d+)[^;]* Build'
+  - regex: '; {0,2}(SmartTab\d+)[^;]{0,50}(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'ZTE'
     model_replacement: '$1'
-  - regex: '; *(?:Blade|BLADE|ZTE-BLADE)([^;/]*) Build'
+  - regex: '; {0,2}(?:Blade|BLADE|ZTE-BLADE)([^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: 'ZTE Blade$1'
     brand_replacement: 'ZTE'
     model_replacement: 'Blade$1'
-  - regex: '; *(?:Skate|SKATE|ZTE-SKATE)([^;/]*) Build'
+  - regex: '; {0,2}(?:Skate|SKATE|ZTE-SKATE)([^;/]*)(?: Build|\) AppleWebKit)'
     device_replacement: 'ZTE Skate$1'
     brand_replacement: 'ZTE'
     model_replacement: 'Skate$1'
-  - regex: '; *(Orange |Optimus )(Monte Carlo|San Francisco) Build'
+  - regex: '; {0,2}(Orange |Optimus )(Monte Carlo|San Francisco)(?: Build|\) AppleWebKit)'
     device_replacement: '$1$2'
     brand_replacement: 'ZTE'
     model_replacement: '$1$2'
-  - regex: '; *(?:ZXY-ZTE_|ZTE\-U |ZTE[\- _]|ZTE-C[_ ])([^;/]+) Build'
+  - regex: '; {0,2}(?:ZXY-ZTE_|ZTE\-U |ZTE[\- _]|ZTE-C[_ ])([^;/]{1,100}?)(?: Build|\) AppleWebKit)'
     device_replacement: 'ZTE $1'
     brand_replacement: 'ZTE'
     model_replacement: '$1'
   # operator specific
-  - regex: '; (BASE) (lutea|Lutea 2|Tab[^;]*) Build'
+  - regex: '; (BASE) (lutea|Lutea 2|Tab[^;]{0,200}?)(?: Build|\) AppleWebKit)'
     device_replacement: '$1 $2'
     brand_replacement: 'ZTE'
     model_replacement: '$1 $2'
-  - regex: '; (Avea inTouch 2|soft stone|tmn smart a7|Movistar[ _]Link) Build'
+  - regex: '; (Avea inTouch 2|soft stone|tmn smart a7|Movistar[ _]Link)(?: Build|\) AppleWebKit)'
     regex_flag: 'i'
     device_replacement: '$1'
     brand_replacement: 'ZTE'
     model_replacement: '$1'
-  - regex: '; *(vp9plus)\)'
+  - regex: '; {0,2}(vp9plus)\)'
     device_replacement: '$1'
     brand_replacement: 'ZTE'
     model_replacement: '$1'
@@ -4437,7 +4809,7 @@ device_parsers:
   # Zync
   # @ref: http://www.zync.in/index.php/our-products/tablet-phablets
   ##########
-  - regex: '; ?(Cloud[ _]Z5|z1000|Z99 2G|z99|z930|z999|z990|z909|Z919|z900) Build/'
+  - regex: '; ?(Cloud[ _]Z5|z1000|Z99 2G|z99|z930|z999|z990|z909|Z919|z900)(?: Build|\) AppleWebKit)'
     device_replacement: '$1'
     brand_replacement: 'Zync'
     model_replacement: '$1'
@@ -4488,7 +4860,7 @@ device_parsers:
     device_replacement: 'Kindle Fire HDX 8.9" 4G'
     brand_replacement: 'Amazon'
     model_replacement: 'Kindle Fire HDX 8.9" 4G'
-  - regex: '; ?Amazon ([^;/]+) Build\b'
+  - regex: '; ?Amazon ([^;/]{1,100}) Build\b'
     device_replacement: '$1'
     brand_replacement: 'Amazon'
     model_replacement: '$1'
@@ -4511,22 +4883,22 @@ device_parsers:
 
   #########
   # Devices from chinese manufacturer(s)
-  # @note: identified by x-wap-profile http://218.249.47.94/Xianghe/.*
+  # @note: identified by x-wap-profile http://218.249.47.94/Xianghe/.{0,200}
   #########
-  - regex: '(sprd)\-([^/]+)/'
+  - regex: '(sprd)\-([^/]{1,50})/'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
   # @ref: http://eshinechina.en.alibaba.com/
-  - regex: '; *(H\d{2}00\+?) Build'
+  - regex: '; {0,2}(H\d{2}00\+?) Build'
     device_replacement: '$1'
     brand_replacement: 'Hero'
     model_replacement: '$1'
-  - regex: '; *(iphone|iPhone5) Build/'
+  - regex: '; {0,2}(iphone|iPhone5) Build/'
     device_replacement: 'Xianghe $1'
     brand_replacement: 'Xianghe'
     model_replacement: '$1'
-  - regex: '; *(e\d{4}[a-z]?_?v\d+|v89_[^;/]+)[^;/]+ Build/'
+  - regex: '; {0,2}(e\d{4}[a-z]?_?v\d+|v89_[^;/]{1,100})[^;/]{1,30} Build/'
     device_replacement: 'Xianghe $1'
     brand_replacement: 'Xianghe'
     model_replacement: '$1'
@@ -4548,7 +4920,7 @@ device_parsers:
   #########
   # Alcatel Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:ALCATEL)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:ALCATEL)[^;]{0,200}; {0,2}([^;,\)]+)'
     device_replacement: 'Alcatel $1'
     brand_replacement: 'Alcatel'
     model_replacement: '$1'
@@ -4556,8 +4928,7 @@ device_parsers:
   #########
   # Asus Windows Phones
   #########
-  #~ - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:ASUS|Asus)[^;]*; *([^;,\)]+)'
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:ASUS|Asus)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:ASUS|Asus)[^;]{0,200}; {0,2}([^;,\)]+)'
     device_replacement: 'Asus $1'
     brand_replacement: 'Asus'
     model_replacement: '$1'
@@ -4565,7 +4936,7 @@ device_parsers:
   #########
   # Dell Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:DELL|Dell)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:DELL|Dell)[^;]{0,200}; {0,2}([^;,\)]+)'
     device_replacement: 'Dell $1'
     brand_replacement: 'Dell'
     model_replacement: '$1'
@@ -4573,7 +4944,7 @@ device_parsers:
   #########
   # HTC Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:HTC|Htc|HTC_blocked[^;]*)[^;]*; *(?:HTC|)([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:HTC|Htc|HTC_blocked[^;]{0,200})[^;]{0,200}; {0,2}(?:HTC|)([^;,\)]+)'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
@@ -4581,7 +4952,7 @@ device_parsers:
   #########
   # Huawei Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:HUAWEI)[^;]*; *(?:HUAWEI |)([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:HUAWEI)[^;]{0,200}; {0,2}(?:HUAWEI |)([^;,\)]+)'
     device_replacement: 'Huawei $1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'
@@ -4589,7 +4960,7 @@ device_parsers:
   #########
   # LG Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:LG|Lg)[^;]*; *(?:LG[ \-]|)([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:LG|Lg)[^;]{0,200}; {0,2}(?:LG[ \-]|)([^;,\)]+)'
     device_replacement: 'LG $1'
     brand_replacement: 'LG'
     model_replacement: '$1'
@@ -4597,15 +4968,15 @@ device_parsers:
   #########
   # Noka Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:rv:11; |)(?:NOKIA|Nokia)[^;]*; *(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?|)(\d{3,10}[^;\)]*)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:rv:11; |)(?:NOKIA|Nokia)[^;]{0,200}; {0,2}(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?|)(\d{3,10}[^;\)]*)'
     device_replacement: 'Lumia $1'
     brand_replacement: 'Nokia'
     model_replacement: 'Lumia $1'
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:NOKIA|Nokia)[^;]*; *(RM-\d{3,})'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:NOKIA|Nokia)[^;]{0,200}; {0,2}(RM-\d{3,})'
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1'
-  - regex: '(?:Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)]|WPDesktop;) ?(?:ARM; ?Touch; ?|Touch; ?|)(?:NOKIA|Nokia)[^;]*; *(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?|)([^;\)]+)'
+  - regex: '(?:Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)]|WPDesktop;) ?(?:ARM; ?Touch; ?|Touch; ?|)(?:NOKIA|Nokia)[^;]{0,200}; {0,2}(?:NOKIA ?|Nokia ?|LUMIA ?|[Ll]umia ?|)([^;\)]+)'
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1'
@@ -4613,7 +4984,7 @@ device_parsers:
   #########
   # Microsoft Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:Microsoft(?: Corporation|))[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|)(?:Microsoft(?: Corporation|))[^;]{0,200}; {0,2}([^;,\)]+)'
     device_replacement: 'Microsoft $1'
     brand_replacement: 'Microsoft'
     model_replacement: '$1'
@@ -4621,7 +4992,7 @@ device_parsers:
   #########
   # Samsung Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:SAMSUNG)[^;]*; *(?:SAMSUNG |)([^;,\.\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:SAMSUNG)[^;]{0,200}; {0,2}(?:SAMSUNG |)([^;,\.\)]+)'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
@@ -4629,7 +5000,7 @@ device_parsers:
   #########
   # Toshiba Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:TOSHIBA|FujitsuToshibaMobileCommun)[^;]*; *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)(?:TOSHIBA|FujitsuToshibaMobileCommun)[^;]{0,200}; {0,2}([^;,\)]+)'
     device_replacement: 'Toshiba $1'
     brand_replacement: 'Toshiba'
     model_replacement: '$1'
@@ -4637,7 +5008,7 @@ device_parsers:
   #########
   # Generic Windows Phones
   #########
-  - regex: 'Windows Phone [^;]+; .*?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)([^;]+); *([^;,\)]+)'
+  - regex: 'Windows Phone [^;]{1,30}; .{0,100}?IEMobile/[^;\)]+[;\)] ?(?:ARM; ?Touch; ?|Touch; ?|WpsLondonTest; ?|)([^;]{1,200}); {0,2}([^;,\)]+)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
@@ -4649,7 +5020,7 @@ device_parsers:
   #########
   # Samsung Bada Phones
   #########
-  - regex: '(?:^|; )SAMSUNG\-([A-Za-z0-9\-]+).* Bada/'
+  - regex: '(?:^|; )SAMSUNG\-([A-Za-z0-9\-]{1,50}).{0,200} Bada/'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
@@ -4657,24 +5028,40 @@ device_parsers:
   #########
   # Firefox OS
   #########
-  - regex: '\(Mobile; ALCATEL ?(One|ONE) ?(Touch|TOUCH) ?([^;/]+)(?:/[^;]+|); rv:[^\)]+\) Gecko/[^\/]+ Firefox/'
+  - regex: '\(Mobile; ALCATEL ?(One|ONE) ?(Touch|TOUCH) ?([^;/]{1,100}?)(?:/[^;]{1,200}|); rv:[^\)]{1,200}\) Gecko/[^\/]{1,200} Firefox/'
     device_replacement: 'Alcatel $1 $2 $3'
     brand_replacement: 'Alcatel'
     model_replacement: 'One Touch $3'
-  - regex: '\(Mobile; (?:ZTE([^;]+)|(OpenC)); rv:[^\)]+\) Gecko/[^\/]+ Firefox/'
+  - regex: '\(Mobile; (?:ZTE([^;]{1,200})|(OpenC)); rv:[^\)]{1,200}\) Gecko/[^\/]{1,200} Firefox/'
     device_replacement: 'ZTE $1$2'
     brand_replacement: 'ZTE'
     model_replacement: '$1$2'
+
+  #########
+  # KaiOS
+  #########
+  - regex: '\(Mobile; ALCATEL([A-Za-z0-9\-]+); rv:[^\)]{1,200}\) Gecko/[^\/]{1,200} Firefox/[^\/]{1,200} KaiOS/'
+    device_replacement: 'Alcatel $1'
+    brand_replacement: 'Alcatel'
+    model_replacement: '$1'
+  - regex: '\(Mobile; LYF\/([A-Za-z0-9\-]{1,100})\/.{0,100};.{0,100}rv:[^\)]{1,100}\) Gecko/[^\/]{1,100} Firefox/[^\/]{1,100} KAIOS/'
+    device_replacement: 'LYF $1'
+    brand_replacement: 'LYF'
+    model_replacement: '$1'
+  - regex: '\(Mobile; Nokia_([A-Za-z0-9\-]{1,100})_.{1,100}; rv:[^\)]{1,100}\) Gecko/[^\/]{1,100} Firefox/[^\/]{1,100} KAIOS/'
+    device_replacement: 'Nokia $1'
+    brand_replacement: 'Nokia'
+    model_replacement: '$1'
 
   ##########
   # NOKIA
   # @note: NokiaN8-00 comes before iphone. Sometimes spoofs iphone
   ##########
-  - regex: 'Nokia(N[0-9]+)([A-z_\-][A-z0-9_\-]*)'
+  - regex: 'Nokia(N[0-9]+)([A-Za-z_\-][A-Za-z0-9_\-]*)'
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1$2'
-  - regex: '(?:NOKIA|Nokia)(?:\-| *)(?:([A-Za-z0-9]+)\-[0-9a-f]{32}|([A-Za-z0-9\-]+)(?:UCBrowser)|([A-Za-z0-9\-]+))'
+  - regex: '(?:NOKIA|Nokia)(?:\-| {0,2})(?:([A-Za-z0-9]+)\-[0-9a-f]{32}|([A-Za-z0-9\-]+)(?:UCBrowser)|([A-Za-z0-9\-]+))'
     device_replacement: 'Nokia $1$2$3'
     brand_replacement: 'Nokia'
     model_replacement: '$1$2$3'
@@ -4683,12 +5070,12 @@ device_parsers:
     brand_replacement: 'Nokia'
     model_replacement: 'Lumia $1'
   # UCWEB Browser on Symbian
-  - regex: '\(Symbian; U; S60 V5; [A-z]{2}\-[A-z]{2}; (SonyEricsson|Samsung|Nokia|LG)([^;/]+)\)'
+  - regex: '\(Symbian; U; S60 V5; [A-z]{2}\-[A-z]{2}; (SonyEricsson|Samsung|Nokia|LG)([^;/]{1,100}?)\)'
     device_replacement: '$1 $2'
     brand_replacement: '$1'
     model_replacement: '$2'
   # Nokia Symbian
-  - regex: '\(Symbian(?:/3|); U; ([^;]+);'
+  - regex: '\(Symbian(?:/3|); U; ([^;]{1,200});'
     device_replacement: 'Nokia $1'
     brand_replacement: 'Nokia'
     model_replacement: '$1'
@@ -4701,7 +5088,7 @@ device_parsers:
     device_replacement: 'BlackBerry $1'
     brand_replacement: 'BlackBerry'
     model_replacement: '$1'
-  - regex: 'Play[Bb]ook.+RIM Tablet OS'
+  - regex: 'Play[Bb]ook.{1,200}RIM Tablet OS'
     device_replacement: 'BlackBerry Playbook'
     brand_replacement: 'BlackBerry'
     model_replacement: 'Playbook'
@@ -4733,7 +5120,7 @@ device_parsers:
     device_replacement: 'Palm Treo $1'
     brand_replacement: 'Palm'
     model_replacement: 'Treo $1'
-  - regex: 'webOS.*(P160U(?:NA|))/(\d+).(\d+)'
+  - regex: 'webOS.{0,200}(P160U(?:NA|))/(\d+).(\d+)'
     device_replacement: 'HP Veer'
     brand_replacement: 'HP'
     model_replacement: 'Veer'
@@ -4741,7 +5128,7 @@ device_parsers:
     device_replacement: 'HP TouchPad'
     brand_replacement: 'HP'
     model_replacement: 'TouchPad'
-  - regex: 'HPiPAQ([A-Za-z0-9]+)/\d+.\d+'
+  - regex: 'HPiPAQ([A-Za-z0-9]{1,20})/\d+\.\d+'
     device_replacement: 'HP iPAQ $1'
     brand_replacement: 'HP'
     model_replacement: 'iPAQ $1'
@@ -4792,6 +5179,10 @@ device_parsers:
     device_replacement: '$1'
     brand_replacement: 'Apple'
     model_replacement: '$1'
+  - regex: '(Watch)(\d+,\d+)'
+    device_replacement: 'Apple $1'
+    brand_replacement: 'Apple'
+    model_replacement: '$1$2'
   - regex: '(Apple Watch)(?:;| Simulator;)'
     device_replacement: '$1'
     brand_replacement: 'Apple'
@@ -4805,18 +5196,18 @@ device_parsers:
     brand_replacement: 'Apple'
     model_replacement: 'iPhone'
   # @note: desktop applications show device info
-  - regex: 'CFNetwork/.* Darwin/\d.*\(((?:Mac|iMac|PowerMac|PowerBook)[^\d]*)(\d+)(?:,|%2C)(\d+)'
+  - regex: 'CFNetwork/.{0,100} Darwin/\d.{0,100}\(((?:Mac|iMac|PowerMac|PowerBook)[^\d]*)(\d+)(?:,|%2C)(\d+)'
     device_replacement: '$1$2,$3'
     brand_replacement: 'Apple'
     model_replacement: '$1$2,$3'
   # @note: newer desktop applications don't show device info
   # This is here so as to not have them recorded as iOS-Device
-  - regex: 'CFNetwork/.* Darwin/\d+\.\d+\.\d+ \(x86_64\)'
+  - regex: 'CFNetwork/.{0,100} Darwin/\d+\.\d+\.\d+ \(x86_64\)'
     device_replacement: 'Mac'
     brand_replacement: 'Apple'
     model_replacement: 'Mac'
   # @note: iOS applications do not show device info
-  - regex: 'CFNetwork/.* Darwin/\d'
+  - regex: 'CFNetwork/.{0,100} Darwin/\d'
     device_replacement: 'iOS-Device'
     brand_replacement: 'Apple'
     model_replacement: 'iOS-Device'
@@ -4860,7 +5251,11 @@ device_parsers:
     device_replacement: 'Asus $1'
     brand_replacement: 'Asus'
     model_replacement: '$1'
-  - regex: '(?:asus.*?ASUS|Asus|ASUS|asus)[\- ;]*((?:Transformer (?:Pad|Prime) |Transformer |Padfone |Nexus[ _]|)[A-Za-z0-9]+)'
+  - regex: '(?:asus.{0,200}?ASUS|Asus|ASUS|asus)[\- ;]*((?:Transformer (?:Pad|Prime) |Transformer |Padfone |Nexus[ _]|)[A-Za-z0-9]+)'
+    device_replacement: 'Asus $1'
+    brand_replacement: 'Asus'
+    model_replacement: '$1'
+  - regex: '(?:ASUS)_([A-Za-z0-9\-]+)'
     device_replacement: 'Asus $1'
     brand_replacement: 'Asus'
     model_replacement: '$1'
@@ -4889,11 +5284,11 @@ device_parsers:
     device_replacement: 'DoCoMo $1'
     brand_replacement: 'DoCoMo'
     model_replacement: '$1'
-  - regex: '([A-Za-z0-9]+)_W;FOMA'
+  - regex: '^.{0,50}?([A-Za-z0-9]{1,30})_W;FOMA'
     device_replacement: 'DoCoMo $1'
     brand_replacement: 'DoCoMo'
     model_replacement: '$1'
-  - regex: '([A-Za-z0-9]+);FOMA'
+  - regex: '^.{0,50}?([A-Za-z0-9]{1,30});FOMA'
     device_replacement: 'DoCoMo $1'
     brand_replacement: 'DoCoMo'
     model_replacement: '$1'
@@ -4901,7 +5296,7 @@ device_parsers:
   ##########
   # htc
   ##########
-  - regex: '\b(?:HTC/|HTC/[a-z0-9]+/|)HTC[ _\-;]? *(.*?)(?:-?Mozilla|fingerPrint|[;/\(\)]|$)'
+  - regex: '\b(?:HTC/|HTC/[a-z0-9]{1,20}/|)HTC[ _\-;]? {0,2}(.{0,200}?)(?:-?Mozilla|fingerPrint|[;/\(\)]|$)'
     device_replacement: 'HTC $1'
     brand_replacement: 'HTC'
     model_replacement: '$1'
@@ -4914,6 +5309,10 @@ device_parsers:
     brand_replacement: 'Huawei'
     model_replacement: '$1'
   - regex: 'HUAWEI-([A-Za-z0-9]+)'
+    device_replacement: 'Huawei $1'
+    brand_replacement: 'Huawei'
+    model_replacement: '$1'
+  - regex: 'HUAWEI ([A-Za-z0-9\-]+)'
     device_replacement: 'Huawei $1'
     brand_replacement: 'Huawei'
     model_replacement: '$1'
@@ -4954,22 +5353,22 @@ device_parsers:
   # HbbTV (European and Australian standard)
   # written before the LG regexes, as LG is making HbbTV too
   ##########
-  - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+ \([^;]*; *(LG)E *; *([^;]*) *;[^;]*;[^;]*;\)'
+  - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+ \( ?;(LG)E ?;([^;]{0,30})'
     device_replacement: '$1'
     brand_replacement: '$2'
     model_replacement: '$3'
-  - regex: '(HbbTV)/1\.1\.1.*CE-HTML/1\.\d;(Vendor/|)(THOM[^;]*?)[;\s].{0,30}(LF[^;]+);?'
+  - regex: '(HbbTV)/1\.1\.1.{0,200}CE-HTML/1\.\d;(Vendor/|)(THOM[^;]{0,200}?)[;\s].{0,30}(LF[^;]{1,200});?'
     device_replacement: '$1'
     brand_replacement: 'Thomson'
     model_replacement: '$4'
-  - regex: '(HbbTV)(?:/1\.1\.1|) ?(?: \(;;;;;\)|); *CE-HTML(?:/1\.\d|); *([^ ]+) ([^;]+);'
+  - regex: '(HbbTV)(?:/1\.1\.1|) ?(?: \(;;;;;\)|); {0,2}CE-HTML(?:/1\.\d|); {0,2}([^ ]{1,30}) ([^;]{1,200});'
     device_replacement: '$1'
     brand_replacement: '$2'
     model_replacement: '$3'
   - regex: '(HbbTV)/1\.1\.1 \(;;;;;\) Maple_2011'
     device_replacement: '$1'
     brand_replacement: 'Samsung'
-  - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+ \([^;]*; *(?:CUS:([^;]*)|([^;]+)) *; *([^;]*) *;.*;'
+  - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+ \([^;]{0,30}; ?(?:CUS:([^;]{0,200})|([^;]{1,200})) ?; ?([^;]{0,30})'
     device_replacement: '$1'
     brand_replacement: '$2$3'
     model_replacement: '$4'
@@ -4979,7 +5378,7 @@ device_parsers:
   ##########
   # LGE NetCast TV
   ##########
-  - regex: 'LGE; (?:Media\/|)([^;]*);[^;]*;[^;]*;?\); "?LG NetCast(\.TV|\.Media|)-\d+'
+  - regex: 'LGE; (?:Media\/|)([^;]{0,200});[^;]{0,200};[^;]{0,200};?\); "?LG NetCast(\.TV|\.Media|)-\d+'
     device_replacement: 'NetCast$2'
     brand_replacement: 'LG'
     model_replacement: '$1'
@@ -4987,11 +5386,11 @@ device_parsers:
   ##########
   # InettvBrowser
   ##########
-  - regex: 'InettvBrowser/[0-9]+\.[0-9A-Z]+ \([^;]*;(Sony)([^;]*);[^;]*;[^\)]*\)'
+  - regex: 'InettvBrowser/[0-9]{1,30}\.[0-9A-Z]{1,30} \([^;]{0,200};(Sony)([^;]{0,200});[^;]{0,200};[^\)]{0,10}\)'
     device_replacement: 'Inettv'
     brand_replacement: '$1'
     model_replacement: '$2'
-  - regex: 'InettvBrowser/[0-9]+\.[0-9A-Z]+ \([^;]*;([^;]*);[^;]*;[^\)]*\)'
+  - regex: 'InettvBrowser/[0-9]{1,30}\.[0-9A-Z]{1,30} \([^;]{0,200};([^;]{0,200});[^;]{0,200};[^\)]{0,10}\)'
     device_replacement: 'Inettv'
     brand_replacement: 'Generic_Inettv'
     model_replacement: '$1'
@@ -5028,7 +5427,7 @@ device_parsers:
     device_replacement: 'Microsoft $1'
     brand_replacement: 'Microsoft'
     model_replacement: '$1'
-  - regex: '(?:MSIE|XBMC).*\b(Xbox)\b'
+  - regex: '(?:MSIE|XBMC).{0,200}\b(Xbox)\b'
     device_replacement: '$1'
     brand_replacement: 'Microsoft'
     model_replacement: '$1'
@@ -5089,12 +5488,12 @@ device_parsers:
   # Samsung
   ##########
   # Samsung Smart-TV
-  - regex: '(SMART-TV); .* Tizen '
+  - regex: '(SMART-TV); .{0,200} Tizen '
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
   # Samsung Symbian Devices
-  - regex: 'SymbianOS/9\.\d.* Samsung[/\-]([A-Za-z0-9 \-]+)'
+  - regex: 'SymbianOS/9\.\d.{0,200} Samsung[/\-]([A-Za-z0-9 \-]+)'
     device_replacement: 'Samsung $1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
@@ -5102,7 +5501,7 @@ device_parsers:
     device_replacement: '$1 $2$3'
     brand_replacement: '$1'
     model_replacement: '$2-$3'
-  - regex: 'SAMSUNG-ANDROID-MMS/([^;/]+)'
+  - regex: 'SAMSUNG-ANDROID-MMS/([^;/]{1,100})'
     device_replacement: '$1'
     brand_replacement: 'Samsung'
     model_replacement: '$1'
@@ -5149,7 +5548,7 @@ device_parsers:
   ##########
   # Sony
   ##########
-  - regex: 'Android [^;]+; ([^ ]+) (Sony)/'
+  - regex: 'Android [^;]{1,200}; ([^ ]+) (Sony)/'
     device_replacement: '$2 $1'
     brand_replacement: '$2'
     model_replacement: '$1'
@@ -5183,27 +5582,33 @@ device_parsers:
   #########
   # Android General Device Matching (far from perfect)
   #########
-  - regex: 'Android[\- ][\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; WOWMobile (.+) Build[/ ]'
+  - regex: 'Android[\- ][\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; WOWMobile (.{1,200})( Build[/ ]|\))'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+\.[\d]+\-update1; [A-Za-z]{2}\-[A-Za-z]{0,2} *; *(.+?) Build[/ ]'
+  - regex: 'Android[\- ][\d]+\.[\d]+\-update1; [A-Za-z]{2}\-[A-Za-z]{0,2} {0,2}; {0,2}(.{1,200}?)( Build[/ ]|\))'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); *[A-Za-z]{2}[_\-][A-Za-z]{0,2}\-? *; *(.+?) Build[/ ]'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); {0,2}[A-Za-z]{2}[_\-][A-Za-z]{0,2}\-? {0,2}; {0,2}(.{1,200}?)( Build[/ ]|\))'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); *[A-Za-z]{0,2}\- *; *(.+?) Build[/ ]'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); {0,2}[A-Za-z]{0,2}\- {0,2}; {0,2}(.{1,200}?)( Build[/ ]|\))'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
   # No build info at all - "Build" follows locale immediately
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); *[a-z]{0,2}[_\-]?[A-Za-z]{0,2};? Build[/ ]'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); {0,2}[a-z]{0,2}[_\-]?[A-Za-z]{0,2};?( Build[/ ]|\))'
     device_replacement: 'Generic Smartphone'
     brand_replacement: 'Generic'
     model_replacement: 'Smartphone'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); *\-?[A-Za-z]{2}; *(.+?) Build[/ ]'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|); {0,3}\-?[A-Za-z]{2}; {0,2}(.{1,50}?)( Build[/ ]|\))'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
-  - regex: 'Android[\- ][\d]+(?:\.[\d]+)(?:\.[\d]+|)(?:;.*|); *(.+?) Build[/ ]'
+  - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]{1,100}?)(?: Build|\) AppleWebKit).{1,200}? Mobile Safari'
+    brand_replacement: 'Generic_Android'
+    model_replacement: '$1'
+  - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]{1,100}?)(?: Build|\) AppleWebKit).{1,200}? Safari'
+    brand_replacement: 'Generic_Android_Tablet'
+    model_replacement: '$1'
+  - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]{1,100}?)(?: Build|\))'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
 
@@ -5228,7 +5633,7 @@ device_parsers:
   ##########
   # Generic Tablet
   ##########
-  - regex: '(Android 3\.\d|Opera Tablet|Tablet; .+Firefox/|Android.*(?:Tab|Pad))'
+  - regex: '(Android 3\.\d|Opera Tablet|Tablet; .{1,100}Firefox/|Android.{0,100}(?:Tab|Pad))'
     regex_flag: 'i'
     device_replacement: 'Generic Tablet'
     brand_replacement: 'Generic'
@@ -5237,7 +5642,7 @@ device_parsers:
   ##########
   # Generic Smart Phone
   ##########
-  - regex: '(Symbian|\bS60(Version|V\d)|\bS60\b|\((Series 60|Windows Mobile|Palm OS|Bada); Opera Mini|Windows CE|Opera Mobi|BREW|Brew|Mobile; .+Firefox/|iPhone OS|Android|MobileSafari|Windows *Phone|\(webOS/|PalmOS)'
+  - regex: '(Symbian|\bS60(Version|V\d)|\bS60\b|\((Series 60|Windows Mobile|Palm OS|Bada); Opera Mini|Windows CE|Opera Mobi|BREW|Brew|Mobile; .{1,200}Firefox/|iPhone OS|Android|MobileSafari|Windows {0,2}Phone|\(webOS/|PalmOS)'
     device_replacement: 'Generic Smartphone'
     brand_replacement: 'Generic'
     model_replacement: 'Smartphone'
@@ -5248,9 +5653,9 @@ device_parsers:
     model_replacement: 'Smartphone'
 
   ##########
-  # Spiders (this is hack...)
+  # Spiders (this is a hack...)
   ##########
-  - regex: '(bot|BUbiNG|zao|borg|DBot|oegp|silk|Xenu|zeal|^NING|CCBot|crawl|htdig|lycos|slurp|teoma|voila|yahoo|Sogou|CiBra|Nutch|^Java/|^JNLP/|Daumoa|Daum|Genieo|ichiro|larbin|pompos|Scrapy|snappy|speedy|spider|msnbot|msrbot|vortex|^vortex|crawler|favicon|indexer|Riddler|scooter|scraper|scrubby|WhatWeb|WinHTTP|bingbot|BingPreview|openbot|gigabot|furlbot|polybot|seekbot|^voyager|archiver|Icarus6j|mogimogi|Netvibes|blitzbot|altavista|charlotte|findlinks|Retreiver|TLSProber|WordPress|SeznamBot|ProoXiBot|wsr\-agent|Squrl Java|EtaoSpider|PaperLiBot|SputnikBot|A6\-Indexer|netresearch|searchsight|baiduspider|YisouSpider|ICC\-Crawler|http%20client|Python-urllib|dataparksearch|converacrawler|Screaming Frog|AppEngine-Google|YahooCacheSystem|fast\-webcrawler|Sogou Pic Spider|semanticdiscovery|Innovazion Crawler|facebookexternalhit|Google.*/\+/web/snippet|Google-HTTP-Java-Client|BlogBridge|IlTrovatore-Setaccio|InternetArchive|GomezAgent|WebThumbnail|heritrix|NewsGator|PagePeeker|Reaper|ZooShot|holmes|NL-Crawler|Pingdom|StatusCake|WhatsApp|masscan|Google Web Preview|Qwantify|Yeti)'
+  - regex: '^.{0,100}(bot|BUbiNG|zao|borg|DBot|oegp|silk|Xenu|zeal|^NING|CCBot|crawl|htdig|lycos|slurp|teoma|voila|yahoo|Sogou|CiBra|Nutch|^Java/|^JNLP/|Daumoa|Daum|Genieo|ichiro|larbin|pompos|Scrapy|snappy|speedy|spider|msnbot|msrbot|vortex|^vortex|crawler|favicon|indexer|Riddler|scooter|scraper|scrubby|WhatWeb|WinHTTP|bingbot|BingPreview|openbot|gigabot|furlbot|polybot|seekbot|^voyager|archiver|Icarus6j|mogimogi|Netvibes|blitzbot|altavista|charlotte|findlinks|Retreiver|TLSProber|WordPress|SeznamBot|ProoXiBot|wsr\-agent|Squrl Java|EtaoSpider|PaperLiBot|SputnikBot|A6\-Indexer|netresearch|searchsight|baiduspider|YisouSpider|ICC\-Crawler|http%20client|Python-urllib|dataparksearch|converacrawler|Screaming Frog|AppEngine-Google|YahooCacheSystem|fast\-webcrawler|Sogou Pic Spider|semanticdiscovery|Innovazion Crawler|facebookexternalhit|Google.{0,200}/\+/web/snippet|Google-HTTP-Java-Client|BlogBridge|IlTrovatore-Setaccio|InternetArchive|GomezAgent|WebThumbnail|heritrix|NewsGator|PagePeeker|Reaper|ZooShot|holmes|NL-Crawler|Pingdom|StatusCake|WhatsApp|masscan|Google Web Preview|Qwantify|Yeti|OgScrper)'
     regex_flag: 'i'
     device_replacement: 'Spider'
     brand_replacement: 'Spider'
@@ -5289,3 +5694,14 @@ device_parsers:
     device_replacement: 'Generic Feature Phone'
     brand_replacement: 'Generic'
     model_replacement: 'Feature Phone'
+
+  #########
+  # Apple
+  # @ref: https://www.apple.com/mac/
+  # @note: lookup Mac OS, but exclude iPad, Apple TV, a HTC phone, Kindle, LG
+  # @note: put this at the end, since it is hard to implement contains foo, but not contain bar1, bar 2, bar 3 in go's re2
+  #########
+  - regex: 'Mac OS'
+    device_replacement: 'Mac'
+    brand_replacement: 'Apple'
+    model_replacement: 'Mac'

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,0 +1,43 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[YAML]]
+deps = ["Base64", "Dates", "Printf"]
+git-tree-sha1 = "78c02bd295bbd0ca330f95e07ccdfcb69f6cbcd4"
+uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+version = "0.4.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"

--- a/test/data/test_device.yaml
+++ b/test/data/test_device.yaml
@@ -1,5 +1,20 @@
 test_cases:
 
+  - user_agent_string: 'atc/1.0 watchOS/5.1.3 model/Watch3,4 hwp/t8004 build/16S535 (6; dt:156)'
+    family: 'Apple Watch'
+    brand: 'Apple'
+    model: 'Watch3,4'
+
+  - user_agent_string: 'atc/1.0 watchOS/5.2 model/Watch4,4 hwp/t8006 build/16T225 (6; dt:193)'
+    family: 'Apple Watch'
+    brand: 'Apple'
+    model: 'Watch4,4'
+
+  - user_agent_string: '(null)/(null) watchOS/5.1.1 model/Watch3,3 hwp/t8004 build/16R600 (6; dt:155)'
+    family: 'Apple Watch'
+    brand: 'Apple'
+    model: 'Watch3,3'
+
   - user_agent_string: 'ALCATEL-OT510A/382 ObigoInternetBrowser/Q05A'
     family: 'Alcatel OT510A'
     brand: 'Alcatel'
@@ -9,6 +24,21 @@ test_cases:
     family: 'Alcatel OH5'
     brand: 'Alcatel'
     model: 'OH5'
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; ALCATEL40440; rv:37.0) Gecko/37.0 Firefox/37.0 KaiOS/1.0'
+    family: 'Alcatel 40440'
+    brand: 'Alcatel'
+    model: '40440'
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-34-070519; Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5'
+    family: 'LYF F300B'
+    brand: 'LYF'
+    model: 'F300B'
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; Nokia_8110_4G; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5.1'
+    family: 'Nokia 8110'
+    brand: 'Nokia'
+    model: '8110'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Amaze_4G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
     family: 'HTC Amaze 4G'
@@ -430,6 +460,11 @@ test_cases:
     brand: 'Sony'
     model: 'PlayStation 4'
 
+  - user_agent_string: 'Mozilla/5.0 (PlayStation 4 5.00) AppleWebKit/601.2 (KHTML, like Gecko)'
+    family: 'PlayStation 4'
+    brand: 'Sony'
+    model: 'PlayStation 4'
+
   - user_agent_string: 'SAMSUNG-C3053/1.0 Openwave/6.2.3 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0'
     family: 'Samsung C3053'
     brand: 'Samsung'
@@ -649,6 +684,31 @@ test_cases:
     family: 'Spider'
     brand: 'Spider'
     model: 'Desktop'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko PTST/1.0'
+    family: 'Spider'
+    brand: 'Spider'
+    model:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.0 Safari/537.36 PTST/1.0'
+    family: 'Spider'
+    brand: 'Spider'
+    model:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.146 Mobile Safari/537.36 PTST/180521.140508'
+    family: 'Spider'
+    brand: 'Spider'
+    model:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.81 Mobile Safari/537.36 PTST/391'
+    family: 'Spider'
+    brand: 'Spider'
+    model:
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Datanyze; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
+    family: 'Spider'
+    brand: 'Spider'
+    model:
 
   - user_agent_string: 'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34'
     family: 'Spider'
@@ -3959,6 +4019,21 @@ test_cases:
     family: 'Apanda A80S'
     brand: 'Apanda'
     model: 'A80S'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36'
+    family: 'Mac'
+    brand: 'Apple'
+    model: 'Mac'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0'
+    family: 'Mac'
+    brand: 'Apple'
+    model: 'Mac'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15'
+    family: 'Mac'
+    brand: 'Apple'
+    model: 'Mac'
 
   - user_agent_string: 'AppleTV/1.1'
     family: 'AppleTV'
@@ -11441,6 +11516,56 @@ test_cases:
     model: 'A9100'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 2.3.3; S300 Build/GRI40) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53005'
+    family: 'S300'
+    brand: 'Generic_Android'
+    model: 'S300'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.1-update1; Ar-kw; EQ U8110) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17'
+    family: 'EQ U8110'
+    brand: 'Generic_Android'
+    model: 'EQ U8110'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.1-update1; Cs-cz; Zt180) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17'
+    family: 'Zt180'
+    brand: 'Generic_Android'
+    model: 'Zt180'
+
+  - user_agent_string: 'Mozilla 5.0 (Linux; U; Android 2.2.1; zh-cn; 3GC101) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31'
+    family: '3GC101'
+    brand: 'Generic_Android'
+    model: '3GC101'
+
+  - user_agent_string: 'Mozilla 5.0 (Linux; U; Android 2.3.1; zh-cn; Newpad-K97) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31'
+    family: 'Newpad-K97'
+    brand: 'Generic_Android'
+    model: 'Newpad-K97'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; -; PP4MT-7) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30'
+    family: 'PP4MT-7'
+    brand: 'Generic_Android'
+    model: 'PP4MT-7'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; -; PP4MT-9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'PP4MT-9'
+    brand: 'Generic_Android'
+    model: 'PP4MT-9'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.1; id; AD350) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Ponsel'
+    family: 'AD350'
+    brand: 'Generic_Android'
+    model: 'AD350'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.1; -us; Ally) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
+    family: 'Ally'
+    brand: 'Generic_Android'
+    model: 'Ally'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 2.3.4; A9100) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768'
+    family: 'A9100'
+    brand: 'Generic_Android'
+    model: 'A9100'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 2.3.3; S300) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53005'
     family: 'S300'
     brand: 'Generic_Android'
     model: 'S300'
@@ -25034,6 +25159,26 @@ test_cases:
     family: 'M702pro'
     brand: 'Iru'
     model: 'M702pro'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1; itel it1508 Plus Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/261.0.0.52.126;]'
+    family: 'Itel it1508 Plus'
+    brand: 'Itel'
+    model: 'it1508 Plus'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; itel A32F Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36'
+    family: 'Itel A32F'
+    brand: 'Itel'
+    model: 'A32F'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; itel W5008 Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.79 Mobile Safari/537.36 Zalo android/12100475'
+    family: 'Itel W5008'
+    brand: 'Itel'
+    model: 'W5008'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; itel L6002P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36'
+    family: 'Itel L6002P'
+    brand: 'Itel'
+    model: 'L6002P'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.2; cs-cz; DE88Plus Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
     family: 'DE88Plus'
@@ -47375,6 +47520,16 @@ test_cases:
     brand: 'Nokia'
     model:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; TA-1053) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36'
+    family: 'Nokia TA-1053'
+    brand: 'Nokia'
+    model: 'TA-1053'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; TA-1032 Build/O00623; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.149 Mobile Safari/537.36 Zalo android/12100486'
+    family: 'Nokia TA-1032'
+    brand: 'Nokia'
+    model: 'TA-1032'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.0.4; NookColor Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31'
     family: 'NookColor'
     brand: 'Nook'
@@ -48019,6 +48174,76 @@ test_cases:
     family: 'Oppo X907'
     brand: 'Oppo'
     model: 'X907'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; F1f Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36'
+    family: 'Oppo F1f'
+    brand: 'Oppo'
+    model: 'F1f'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; F1w Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.132 Mobile Safari/537.36 Zalo android/12100486'
+    family: 'Oppo F1w'
+    brand: 'Oppo'
+    model: 'F1w'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; A33f) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36'
+    family: 'Oppo A33f'
+    brand: 'Oppo'
+    model: 'A33f'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1; A33w Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.162 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/264.0.0.44.111;]'
+    family: 'Oppo A33w'
+    brand: 'Oppo'
+    model: 'A33w'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; A51w) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36'
+    family: 'Oppo A51w'
+    brand: 'Oppo'
+    model: 'A51w'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; R7sf Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.149 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/263.0.0.46.121;]'
+    family: 'Oppo R7sf'
+    brand: 'Oppo'
+    model: 'R7sf'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1.1; R7kf) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36'
+    family: 'Oppo R7kf'
+    brand: 'Oppo'
+    model: 'R7kf'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; RMX1811 Build/PKQ1.190319.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.162 Mobile Safari/537.36 Zalo/1.0'
+    family: 'Oppo RMX1811'
+    brand: 'Oppo'
+    model: 'RMX1811'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; PADM00 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 Zalo/1.0'
+    family: 'Oppo PADM00'
+    brand: 'Oppo'
+    model: 'PADM00'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; PCAM10 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36 Zalo android/12100438'
+    family: 'Oppo PCAM10'
+    brand: 'Oppo'
+    model: 'PCAM10'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; CPH2035) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36'
+    family: 'Oppo CPH2035'
+    brand: 'Oppo'
+    model: 'CPH2035'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1; A1601 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36'
+    family: 'Oppo F1s'
+    brand: 'Oppo'
+    model: 'A1601'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1; A1601) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36'
+    family: 'Oppo F1s'
+    brand: 'Oppo'
+    model: 'A1601'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1; A1601 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 Zalo/1.0'
+    family: 'Oppo F1s'
+    brand: 'Oppo'
+    model: 'A1601'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1.1; th-th; TP-701 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/1.4 Version/4.0 Mobile Safari/534.30'
     family: 'Orion TP-701'
@@ -58044,6 +58269,16 @@ test_cases:
     family: 'Samsung GT-S8600-ORANGE'
     brand: 'Samsung'
     model: 'GT-S8600-ORANGE'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G9500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36'
+    family: 'Samsung SM-G9500'
+    brand: 'Samsung'
+    model: 'SM-G9500'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G9500 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.3 Chrome/67.0.3396.87 Mobile Safari/537.36'
+    family: 'Samsung SM-G9500'
+    brand: 'Samsung'
+    model: 'SM-G9500'
 
   - user_agent_string: 'UCWEB/2.0 (Symbian; U; S60 V5; Pt-BR; SamsungI8910) U2/1.0.0 UCBrowser/8.9.0.277 U2/1.0.0 Mobile'
     family: 'Samsung I8910'
@@ -77425,6 +77660,26 @@ test_cases:
     brand: 'XiaoMi'
     model: 'Redmi Note 2'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; MIX Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.1'
+    family: 'XiaoMi MIX'
+    brand: 'XiaoMi'
+    model: 'MIX'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 9; MIX 2S Build/PKQ1.180729.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.7.3'
+    family: 'XiaoMi MIX 2S'
+    brand: 'XiaoMi'
+    model: 'MIX 2S'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; MIX 2 Build/OPR1.170623.027) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.1'
+    family: 'XiaoMi MIX 2'
+    brand: 'XiaoMi'
+    model: 'MIX 2'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Mi A2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'XiaoMi Mi A2'
+    brand: 'XiaoMi'
+    model: 'Mi A2'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.1.1; XOLO A1000 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
     family: 'Xolo A1000'
     brand: 'Xolo'
@@ -79955,6 +80210,11 @@ test_cases:
     brand: 'OnePlus'
     model: 'ONE E1003'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; ONEPLUS A5010) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36'
+    family: 'OnePlus ONEPLUS A5010'
+    brand: 'OnePlus'
+    model: 'ONEPLUS A5010'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM1.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36'
     family: 'Pixel'
     brand: 'Google'
@@ -79975,6 +80235,11 @@ test_cases:
     brand: 'Google'
     model: 'Pixel 2'
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Pixel 2 XL'
+    brand: 'Google'
+    model: 'Pixel 2 XL'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0; RCT6773W22B Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85'
     family: 'RCT6773W22B'
     brand: 'RCA'
@@ -79984,6 +80249,11 @@ test_cases:
     family: 'RCA G1'
     brand: 'RCA'
     model: 'G1'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.4.2; SC-01F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36'
+    family: 'SC-01F'
+    brand: 'Samsung'
+    model: 'SC-01F'
 
   - user_agent_string: 'WhatsApp/2.17.70 W'
     family: 'Spider'
@@ -80084,3 +80354,138 @@ test_cases:
     family: 'Samsung SM-A520F'
     brand: 'Samsung'
     model: 'SM-A520F'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; ANE-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei ANE-LX1'
+    brand: 'Huawei'
+    model: 'ANE-LX1'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; PRA-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei PRA-LX1'
+    brand: 'Huawei'
+    model: 'PRA-LX1'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0; ALE-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei ALE-L21'
+    brand: 'Huawei'
+    model: 'ALE-L21'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; LDN-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei LDN-L21'
+    brand: 'Huawei'
+    model: 'LDN-L21'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0; CAM-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei CAM-L03'
+    brand: 'Huawei'
+    model: 'CAM-L03'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; ATU-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei ATU-L21'
+    brand: 'Huawei'
+    model: 'ATU-L21'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; RNE-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei RNE-L21'
+    brand: 'Huawei'
+    model: 'RNE-L21'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; EVA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei EVA-L09'
+    brand: 'Huawei'
+    model: 'EVA-L09'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0; DIG-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Huawei DIG-L01'
+    brand: 'Huawei'
+    model: 'DIG-L01'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.1.1; SM-J510FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Samsung SM-J510FN'
+    brand: 'Samsung'
+    model: 'SM-J510FN'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; ASUS_X018D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
+    family: 'Asus X018D'
+    brand: 'Asus'
+    model: 'X018D'
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 10; SH-01M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36'
+    family: 'SH-01M'
+    brand: 'Sharp'
+    model: 'SH-01M'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; SHV46) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36'
+    family: 'SHV46'
+    brand: 'Generic_Android'
+    model: 'SHV46'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; SHV46 Build/PKQ1.190626.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.93 Mobile Safari/537.36'
+    family: 'SHV46'
+    brand: 'Generic_Android'
+    model: 'SHV46'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; 801LV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36'
+    family: '801LV'
+    brand: 'Generic_Android_Tablet'
+    model: '801LV'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; KYT33 Build/3.020VE.0072.a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Safari/537.36'
+    family: 'KYT33'
+    brand: 'Generic_Android_Tablet'
+    model: 'KYT33'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible;AspiegelBot)'
+    family: 'Spider'
+    brand: 'Spider'
+    model: 'Desktop'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)'
+    family: 'Spider'
+    brand: 'Spider'
+    model: 'Smartphone'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.3 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+    family: 'iPhone'
+    brand: 'Apple'
+    model: 'iPhone'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile DuckDuckGo/5 Safari/537.36'
+    family: 'Generic Smartphone'
+    brand: 'Generic'
+    model: 'Smartphone'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0; Thor E Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36'
+    family: 'Thor E'
+    brand: 'Vernee'
+    model: 'Thor'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0; thor Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36'
+    family: 'Thor'
+    brand: 'Vernee'
+    model: 'Thor'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0; Apollo Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36'
+    family: 'Apollo Lite'
+    brand: 'Vernee'
+    model: 'Apollo'
+
+  - user_agent_string: 'Dalvik/2.1.0 (Linux; U; Android 9; LLD-AL10 Build/HONORLLD-AL10)'
+    family: 'Huawei Honor LLD-AL10'
+    brand: 'Huawei'
+    model: 'Honor LLD-AL10'
+
+  - user_agent_string: 'Dalvik/1.6.0 (Linux; U; Android 4.4.2; Che2-TL00M Build/HonorChe2-TL00M)'
+    family: 'Huawei Honor Che2-TL00M'
+    brand: 'Huawei'
+    model: 'Honor Che2-TL00M'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Pandora/1904.1.1'
+    family: 'iPhone'
+    brand: 'Apple'
+    model: 'iPhone'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57 Pandora/1902.1'
+    family: 'iPad'
+    brand: 'Apple'
+    model: 'iPad'
+

--- a/test/data/test_os.yaml
+++ b/test/data/test_os.yaml
@@ -1,5 +1,26 @@
 test_cases:
 
+  - user_agent_string: 'atc/1.0 watchOS/5.1.3 model/Watch3,4 hwp/t8004 build/16S535 (6; dt:156)'
+    family: 'WatchOS'
+    major: '5'
+    minor: '1'
+    patch: '3'
+    patch_minor:
+
+  - user_agent_string: 'atc/1.0 watchOS/5.2 model/Watch4,4 hwp/t8006 build/16T225 (6; dt:193)'
+    family: 'WatchOS'
+    major: '5'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: '(null)/(null) watchOS/5.1.1 model/Watch3,3 hwp/t8004 build/16R600 (6; dt:155)'
+    family: 'WatchOS'
+    major: '5'
+    minor: '1'
+    patch: '1'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true'
     family: 'Android'
     major:
@@ -119,6 +140,34 @@ test_cases:
     patch: '2'
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; motorola one power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36'
+    family: 'Android'
+    major: '9'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 10; SM-G970F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3396.81 Mobile Safari/537.36'
+    family: 'Android'
+    major: '10'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Android'
+    major: '9'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9.1.2; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Android'
+    major: '9'
+    minor: '1'
+    patch: '2'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500/S8500XXJEE; U; Bada/1.0; nl-nl) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B'
     family: 'Bada'
     major: '1'
@@ -228,6 +277,27 @@ test_cases:
     family: 'Firefox OS'
     major:
     minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:37.0) Gecko/37.0 Firefox/37.0 KaiOS/1.0'
+    family: 'KaiOS'
+    major: '1'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5.1'
+    family: 'KaiOS'
+    major: '2'
+    minor: '5'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:68.0) KAIOS/3.0'
+    family: 'KaiOS'
+    major: '3'
+    minor: '0'
     patch:
     patch_minor:
 
@@ -422,6 +492,13 @@ test_cases:
 
   - user_agent_string: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
     family: 'Other'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Datanyze; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
+    family: 'Linux'
     major:
     minor:
     patch:
@@ -736,15 +813,15 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'ICE Browser/5.05 (Java 1.4.0; Windows 2000 5.0 x86)'
-    family: 'Windows 2000'
-    major:
+    family: 'Windows'
+    major: '2000'
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'NCSA_Mosaic/2.0 (Windows 3.1)'
-    family: 'Windows 3.1'
-    major:
+    family: 'Windows'
+    major: '3.1'
     minor:
     patch:
     patch_minor:
@@ -785,6 +862,13 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'PAN GlobalProtect/4.1.2-11 (Microsoft Windows 10 Pro , 64-bit)'
+    family: 'Windows'
+    major: '10'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'PAN GlobalProtect/5.0.0-87 (Microsoft Windows 10 Pro , 64-bit) Mozilla/5.0 (Windows NT 6.2; Win64; x64; Trident/7.0; rv:11.0) like Gecko'
     family: 'Windows'
     major: '10'
     minor:
@@ -1005,6 +1089,13 @@ test_cases:
     family: 'Sony'
     major: '2011'
     minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Sailfish 3.0; Mobile; rv:45.0) Gecko/45.0 Firefox/45.0 SailfishBrowser/1.0'
+    family: 'Sailfish'
+    major: '3'
+    minor: '0'
     patch:
     patch_minor:
 
@@ -2103,6 +2194,160 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'App/1.0.0 CFNetwork/976 Darwin/18.2.0'
+    family: 'iOS'
+    major: '12'
+    minor: '1'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/978.0.7 Darwin/18.5.0'
+    family: 'iOS'
+    major: '12'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/978.0.7 Darwin/18.6.0'
+    family: 'iOS'
+    major: '12'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/978.0.7 Darwin/18.7.0'
+    family: 'iOS'
+    major: '12'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1107.1 Darwin/19.0.0'
+    family: 'iOS'
+    major: '13'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1098.7 Darwin/19.0.0'
+    family: 'iOS'
+    major: '13'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1121.2.2 Darwin/19.2.0'
+    family: 'iOS'
+    major: '13'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1121.2.2 Darwin/19.3.0'
+    family: 'iOS'
+    major: '13'
+    minor: '3'
+    patch: '1'
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1125.2 Darwin/19.4.0'
+    family: 'iOS'
+    major: '13'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1126 Darwin/19.5.0'
+    family: 'iOS'
+    major: '13'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1128.0.1 Darwin/19.6.0'
+    family: 'iOS'
+    major: '13'
+    minor: '6'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1197 Darwin/20.0.0'
+    family: 'iOS'
+    major: '14'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1179.0.1 Darwin/20.0.0'
+    family: 'iOS'
+    major: '14'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1200.1 Darwin/20.1.0'
+    family: 'iOS'
+    major: '14'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1209 Darwin/20.2.0'
+    family: 'iOS'
+    major: '14'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1220.1 Darwin/20.3.0'
+    family: 'iOS'
+    major: '14'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1237 Darwin/20.4.0'
+    family: 'iOS'
+    major: '14'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1206 Darwin/20.1.0'
+    family: 'iOS'
+    major: '14'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1209 Darwin/20.2.0'
+    family: 'iOS'
+    major: '14'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1220.1 Darwin/20.3.0'
+    family: 'iOS'
+    major: '14'
+    minor: '4'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1236 Darwin/20.4.0'
+    family: 'iOS'
+    major: '14'
+    minor: '5'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'App/1.0.0 CFNetwork/1233 Darwin/20.4.0'
+    family: 'iOS'
+    major: '14'
+    minor: '5'
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU 7_0_6 like Mac OS X; en_GB) AppleWebKit (KHTML, like Gecko) Mobile [OKMagazine/4.0.1 (iOS/7.0.6)] [LiteApps]'
     family: 'iOS'
     major: '7'
@@ -2363,6 +2608,13 @@ test_cases:
     patch: '1'
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU iPad OS 14_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+    family: 'iOS'
+    major: '14'
+    minor: '4'
+    patch: '1'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit/538.1 (KHTML, like Gecko) SamsungBrowser/1.0 TV Safari/538.1'
     family: 'Tizen'
     major: '2'
@@ -2417,6 +2669,13 @@ test_cases:
     major: '9'
     minor: '3'
     patch: '4'
+    patch_minor:
+
+  - user_agent_string: 'Zendesk for iPhone 1.2.1 (4395)'
+    family: 'iOS'
+    major:
+    minor:
+    patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0+(Macintosh;+Intel+Mac+OS+X+10_11_6)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/52.0.2743.116+Safari/537.36'
@@ -2552,7 +2811,6 @@ test_cases:
     patch:
     patch_minor:
 
-
   - user_agent_string: 'MyApp/1.0 CFNetwork/893.13.1 Darwin/17.3.0 (x86_64)'
     family: 'Mac OS X'
     major: '10'
@@ -2630,6 +2888,27 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'ibm-cos-sdk-java/2.3.0 Linux/4.9.0-8-amd64 Java_HotSpot(TM)_64-Bit_Server_VM/9.0.4+11/9.0.4'
+    family: 'Linux'
+    major: '4'
+    minor: '9'
+    patch: '0'
+    patch_minor:
+
+  - user_agent_string: 'aws-sdk-dotnet-45/3.3.11.0 aws-sdk-dotnet-core/3.3.17.10 .NET_Runtime/4.0 .NET_Framework/4.0 OS/Microsoft_Windows_NT_6.2.9200.0 ClientSync'
+    family: 'Windows'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'rusoto/0.36.0 rust/1.35.0 linux'
+    family: 'Linux'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'SalesforceMobileSDK/5.3.0 android mobile/8.0.0 (SM-G955F) Salesforce1/15.2 Native uid_c4589f605fad8c7e ftr_ Cordova/6.2.3'
     family: 'Android'
     major: '8'
@@ -2678,3 +2957,137 @@ test_cases:
     minor:
     patch:
     patch_minor:
+
+  - user_agent_string: 'ViaFree-DK/3.8.3 (com.MTGx.ViaFree.dk; build:7383; iOS 12.1.0) Alamofire/4.7.0'
+    family: 'iOS'
+    major: '12'
+    minor: '1'
+    patch: '0'
+    patch_minor:
+
+  - user_agent_string: 'Viafree-tvOS-DK/3.7.1 (com.MTGx.ViaFree.dk; build:7341; tvOS 12.1.0) Alamofire/4.7.0'
+    family: 'tvOS'
+    major: '12'
+    minor: '1'
+    patch: '0'
+    patch_minor:
+
+  - user_agent_string: 'iTunes/12.7.1 (Windows; Microsoft Windows 7 Ultimate Edition Service Pack 1 (Build 7601)) AppleWebKit/7604.3005.2001.1'
+    family: 'Windows'
+    major: '7'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'iTunes/12.1.3 (Windows; Microsoft Windows XP Professional Service Pack 3 (Build 2600)) AppleWebKit/7600.1017.9000.3'
+    family: 'Windows'
+    major: 'XP'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'iTunes/12.1.3 (Windows; Microsoft Windows Vista Business Edition Service Pack 2 (Build 6002)) AppleWebKit/7600.1017.9000.3  '
+    family: 'Windows'
+    major: 'Vista'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 5.01; Windows 98; Linux 3.3.8-3.3) [Netgem; 7.7.01-51; i-Player; netbox; sezmi_totalgem]'
+    family: 'Windows'
+    major: '98'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/2.0 (compatible; MSIE 3.0; Windows 3.1)'
+    family: 'Windows'
+    major: '3.1'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 4.0; rv:52.0) Gecko/20100101 Firefox/52.0'
+    family: 'Windows'
+    major: 'NT'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 5.0; Windows ME) Opera 5.11 [de]'
+    family: 'Windows'
+    major: 'ME'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Microsoft Internet Explorer/1.0 (Windows 95)'
+    family: 'Windows'
+    major: '95'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows CE,BrailleNote; IEMobile 7.11)'
+    family: 'Windows'
+    major: 'CE'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows 2000; U) Opera 7.0 [en]'
+    family: 'Windows'
+    major: '2000'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (compatible;AspiegelBot)'
+    family: 'Other'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)'
+    family: 'Other'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.3 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+    family: 'iOS'
+    major: '14'
+    minor: '3'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile DuckDuckGo/5 Safari/537.36'
+    family: 'Android'
+    major: '11'
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Pandora/1904.1.1'
+    family: 'iOS'
+    major: '12'
+    minor: '2'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Pandora/1904.1 Android/8.0.0 heroqlteusc (ExoPlayerLib1.5.14.1)'
+    family: 'Android'
+    major: '8'
+    minor: '0'
+    patch: '0'
+    patch_minor:
+
+  - user_agent_string: 'Pandora Audio/1903.2 (Linux;Android 7.0) ExoPlayerLib/2.8.2'
+    family: 'Android'
+    major: '7'
+    minor: '0'
+    patch: 
+    patch_minor:
+

--- a/test/data/test_ua.yaml
+++ b/test/data/test_ua.yaml
@@ -1,4 +1,81 @@
 test_cases:
+  - user_agent_string: 'Luminary/1.0'
+    family: 'Luminary'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Luminary/70 CFNetwork/978.0.7 Darwin/18.5.0'
+    family: 'Luminary'
+    major: '70'
+    minor:
+    patch:
+
+  - user_agent_string: 'Luminary/70 CFNetwork/975.0.3 Darwin/18.2.0'
+    family: 'Luminary'
+    major: '70'
+    minor:
+    patch:
+
+  - user_agent_string: 'Luminary/1.0.3 build 71/iOS 12.2'
+    family: 'Luminary'
+    major: '1'
+    minor: '0'
+    patch: '3'
+
+  - user_agent_string: 'Luminary/1.0.2 build 57/Android SDK 28'
+    family: 'Luminary'
+    major: '1'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'Luminary/1.0.2 build 57/Android SDK 23'
+    family: 'Luminary'
+    major: '1'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'Luminary/70 CFNetwork/976 Darwin/18.2.0'
+    family: 'Luminary'
+    major: '70'
+    minor:
+    patch:
+
+  - user_agent_string: 'Luminary/70 CFNetwork/978.0.7 Darwin/18.6.0'
+    family: 'Luminary'
+    major: '70'
+    minor:
+    patch:
+
+  - user_agent_string: 'Luminary/1.0.2 build 57/Android SDK 26'
+    family: 'Luminary'
+    major: '1'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'LuminaryStage/3311 CFNetwork/978.0.7 Darwin/18.5.0'
+    family: 'Luminary'
+    major: '3311'
+    minor:
+    patch:
+
+  - user_agent_string: 'fakeLuminary/1.0'
+    family: 'Other'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'atc/1.0 watchOS/5.1.3 model/Watch3,4 hwp/t8004 build/16S535 (6; dt:156)'
+    family: 'Apple Watch App'
+    major: '3'
+    minor: '4'
+    patch:
+
+  - user_agent_string: 'atc/1.0 watchOS/5.2 model/Watch4,4 hwp/t8006 build/16T225 (6; dt:193)'
+    family: 'Apple Watch App'
+    major: '4'
+    minor: '4'
+    patch:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; en-US) AppleWebKit/531.9 (KHTML, like Gecko) AdobeAIR/2.5.1'
     family: 'AdobeAIR'
@@ -204,11 +281,23 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Macintosh) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.98 Safari/537.36 CreativeCloud/4.8.1.435'
+    family: 'Adobe CreativeCloud'
+    major: '4'
+    minor: '8'
+    patch: '1'
+
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/11.0.660.0)'
     family: 'Chrome Frame'
     major: '11'
     minor: '0'
     patch: '660'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36'
+    family: 'Chrome Mobile WebView'
+    major: '68'
+    minor: '0'
+    patch: '3440'
 
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47W; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36'
     family: 'Chrome Mobile WebView'
@@ -301,7 +390,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'Twitterbot/1.0'
-    family: 'TwitterBot'
+    family: 'Twitterbot'
     major: '1'
     minor: '0'
     patch:
@@ -311,6 +400,12 @@ test_cases:
     major: '2'
     minor: '17'
     patch: '70'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.1pre) Gecko/20090717 Ubuntu/9.04 (jaunty) Shiretoko/3.5.1pre'
+    family: 'Firefox (Shiretoko)'
+    major: '3'
+    minor: '5'
+    patch: '1pre'
 
   - user_agent_string: 'Mozilla/5.0 (X11; Linux i686 (x86_64); rv:2.0b4) Gecko/20100818 Firefox/4.0b4'
     family: 'Firefox Beta'
@@ -504,17 +599,41 @@ test_cases:
     minor: '0'
     patch: '2'
 
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 ManagedBrowser/20181024.1'
+    family: 'Mobile Safari UI/WKWebView'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15'
+    family: 'Safari'
+    major: '12'
+    minor: '1'
+    patch: '2'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+    family: 'Mobile Safari UI/WKWebView'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 ManagedBrowser/20181024.1'
+    family: 'Mobile Safari UI/WKWebView'
+    major:
+    minor:
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 (iPod touch; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69'
     family: 'Mobile Safari UI/WKWebView'
-    major: '9'
-    minor: '3'
-    patch: '2'
+    major:
+    minor:
+    patch:
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D257'
     family: 'Mobile Safari UI/WKWebView'
-    major: '7'
-    minor: '1'
-    patch: '2'
+    major:
+    minor:
+    patch:
 
   - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.3a1) Gecko/20100208 MozillaDeveloperPreview/3.7a1 (.NET CLR 3.5.30729)'
     family: 'MozillaDeveloperPreview'
@@ -750,7 +869,7 @@ test_cases:
     minor: '53'
     patch:
 
-  - user_agent_string: 'User agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.20 Safari/537.36 OPR/15.0.1147.18 (Edition Next)'
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.20 Safari/537.36 OPR/15.0.1147.18 (Edition Next)'
     family: 'Opera'
     major: '15'
     minor: '0'
@@ -960,6 +1079,12 @@ test_cases:
     minor: '0'
     patch:
 
+  - user_agent_string: 'Superhuman'
+    family: 'Superhuman'
+    major:
+    minor:
+    patch:
+
   - user_agent_string: 'YahooMobileMail/1.0 (Android Mail; 1.3.10) (supersonic;HTC;PC36100;2.3.5/GRJ90)'
     family: 'YahooMobileMail'
     major: '1'
@@ -1037,6 +1162,12 @@ test_cases:
     major: '1'
     minor: '3'
     patch: '45'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU OS 10_2_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) 1Password/6.4.5 (like Version/10.2.1 Mobile/14D27 Safari/600.1.4)'
+    family: '1Password'
+    major: '6'
+    minor: '4'
+    patch: '5'
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.220 Whale/1.3.50.3 Safari/537.36'
     family: 'Whale'
@@ -1790,6 +1921,36 @@ test_cases:
     major: '1'
     minor: '0'
     patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko PTST/1.0'
+    family: 'WebPageTest.org bot'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.0 Safari/537.36 PTST/1.0'
+    family: 'WebPageTest.org bot'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.146 Mobile Safari/537.36 PTST/180521.140508'
+    family: 'WebPageTest.org bot'
+    major: '180521'
+    minor: '140508'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.81 Mobile Safari/537.36 PTST/391'
+    family: 'WebPageTest.org bot'
+    major: '391'
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (X11; Datanyze; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
+    family: 'Datanyze'
+    major:
+    minor:
+    patch:
 
   - user_agent_string: 'CazoodleBot/CazoodleBot-0.1 (CazoodleBot Crawler; http://www.cazoodle.com/cazoodlebot; cazoodlebot@cazoodle.com)'
     family: 'CazoodleBot'
@@ -3954,6 +4115,18 @@ test_cases:
     minor: '7'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Sailfish 3.0; Mobile; rv:45.0) Gecko/45.0 Firefox/45.0 SailfishBrowser/1.0'
+    family: 'Sailfish Browser'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Sailfish 3.0; Mobile; rv:45.0) Gecko/45.0 Firefox/45.0 SailfishBrowser/1.2.3'
+    family: 'Sailfish Browser'
+    major: '1'
+    minor: '2'
+    patch: '3'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG GT-I9506-ORANGE Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36'
     family: 'Samsung Internet'
     major: '2'
@@ -4735,7 +4908,7 @@ test_cases:
     patch:
 
   - user_agent_string: 'FAST-mSEARCH Crawler 0.1 (bergum@fast.no)'
-    family: 'mSEARCH Crawler'
+    family: 'FAST-mSEARCH Crawler'
     major: '0'
     minor: '1'
     patch:
@@ -6560,6 +6733,13 @@ test_cases:
     patch: '0'
     patch_minor: '14'
 
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15G77 [FBAN/FBIOS;FBAV/194.0.0.38.99;FBBV/127868476;FBDV/iPhone7,2;FBMD/iPhone;FBSN/iOS;FBSV/11.4.1;FBSS/2;FBCR/OrangeBotswana;FBID/phone;FBLC/en_GB;FBOP/5;FBRV/128807018]'
+    family: 'Facebook'
+    major: '194'
+    minor: '0'
+    patch: '0'
+    patch_minor: '38'
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_4 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B350 [Pinterest/iOS]'
     family: 'Pinterest'
     major:
@@ -6676,9 +6856,9 @@ test_cases:
 
   - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile'
     family: 'Mobile Safari UI/WKWebView'
-    major: '4'
-    minor: '3'
-    patch: '2'
+    major:
+    minor:
+    patch:
 
   - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari'
     family: 'Mobile Safari'
@@ -6751,6 +6931,18 @@ test_cases:
     major: '12'
     minor: '0'
     patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 EdgiOS/44.5.0.10 Mobile/15E148 Safari/604.1'
+    family: 'Edge Mobile'
+    major: '44'
+    minor: '5'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM4.171019.021.D1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36 EdgA/42.0.0.2057'
+    family: 'Edge Mobile'
+    major: '42'
+    minor: '0'
+    patch: '0'
 
   - user_agent_string: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.11 Chrome/47.0.2526.110 Brave/0.36.5 Safari/537.36'
     family: 'Brave'
@@ -6836,6 +7028,12 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Mozilla/4.0 (compatible; ms-office; MSOffice 16)'
+    family: 'Outlook'
+    major: '2016'
+    minor:
+    patch:
+
   - user_agent_string: 'Outlook-Express/7.0 (MSIE 7.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; TmstmpExt)'
     family: 'Windows Live Mail'
     major:
@@ -6902,6 +7100,18 @@ test_cases:
     minor: '45'
     patch: '2454'
 
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Mobile/15A372 Safari Line/7.12.0'
+    family: 'LINE'
+    major: '7'
+    minor: '12'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 5.1; FTJ152B Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36 Line/6.4.1'
+    family: 'LINE'
+    major: '6'
+    minor: '4'
+    patch: '1'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.1.2; GT-S7710 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile'
     family: 'Chrome Mobile'
     major: '18'
@@ -6922,6 +7132,18 @@ test_cases:
     minor: '0'
     patch: '0'
     patch_minor: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 6.0.1; ru-ru; Redmi 4 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.3.6-g'
+    family: 'MiuiBrowser'
+    major: '10'
+    minor: '3'
+    patch: '6'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 7.1.2; ru-ru; Redmi 4A Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/Mint Browser/1.3.3'
+    family: 'Mint Browser'
+    major: '1'
+    minor: '3'
+    patch: '3'
 
   - user_agent_string: 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.41 (KHTML, like Gecko) Large Screen WebAppManager Safari/537.41'
     family: 'Safari'
@@ -7175,6 +7397,12 @@ test_cases:
     minor: '14'
     patch:
 
+  - user_agent_string: 'wget2/1.99.2'
+    family: 'wget2'
+    major: '1'
+    minor: '99'
+    patch: '2'
+
   - user_agent_string: 'Windows-Update-Agent/7.9.9600.17729 Client-Protocol/1.21'
     family: 'Windows-Update-Agent'
     major: '7'
@@ -7423,9 +7651,9 @@ test_cases:
 
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) AppleNews/608.0.1 Version/2.0.1'
     family: 'Mobile Safari UI/WKWebView'
-    major: '10'
+    major: '2'
     minor: '0'
-    patch: '2'
+    patch: '1'
 
   - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; InfoPath.3)'
     family: 'IE'
@@ -7573,6 +7801,61 @@ test_cases:
     minor: '8'
     patch: '1'
 
+  - user_agent_string: 'akka-http/10.0.10'
+    family: 'akka-http'
+    major: '10'
+    minor: '0'
+    patch: '10'
+
+  - user_agent_string: 'Python/3.6 aiohttp/3.5.4'
+    family: 'Python aiohttp'
+    major: '3'
+    minor: '5'
+    patch: '4'
+
+  - user_agent_string: 'unirest-java/1.3.11'
+    family: 'unirest-java'
+    major: '1'
+    minor: '3'
+    patch: '11'
+
+  - user_agent_string: 'axios/0.18.0'
+    family: 'axios'
+    major: '0'
+    minor: '18'
+    patch: '0'
+
+  - user_agent_string: 'got/9.6.0 (https://github.com/sindresorhus/got)'
+    family: 'got'
+    major: '9'
+    minor: '6'
+    patch: '0'
+
+  - user_agent_string: 'S3Gof3r'
+    family: 'S3Gof3r'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'rusoto/0.36.0 rust/1.35.0 linux'
+    family: 'rusoto'
+    major: '0'
+    minor: '36'
+    patch: '0'
+
+  - user_agent_string: 'ibm-cos-sdk-java/2.3.0 Linux/4.9.0-8-amd64 Java_HotSpot(TM)_64-Bit_Server_VM/9.0.4+11/9.0.4'
+    family: 'ibm-cos-sdk-java'
+    major: '2'
+    minor: '3'
+    patch: '0'
+
+  - user_agent_string: 'aws-sdk-dotnet-45/3.3.11.0 aws-sdk-dotnet-core/3.3.17.10 .NET_Runtime/4.0 .NET_Framework/4.0 OS/Microsoft_Windows_NT_6.2.9200.0 ClientSync'
+    family: 'aws-sdk-dotnet-45'
+    major: '3'
+    minor: '3'
+    patch: '11'
+    patch_minor: '0'
+
   - user_agent_string: 'Boto/2.48.0 Python/2.7.14 Linux/4.2.0-41-generic'
     family: 'Boto'
     major: '2'
@@ -7699,6 +7982,12 @@ test_cases:
     minor: '2'
     patch:
 
+  - user_agent_string: 'AnyConnect/4.1.1234'
+    family: 'AnyConnect'
+    major: '4'
+    minor: '1'
+    patch: '1234'
+
   - user_agent_string: 'YahooMailProxy; https://help.yahoo.com/kb/yahoo-mail-proxy-SLN28749.html'
     family: 'YahooMailProxy'
     major:
@@ -7712,8 +8001,570 @@ test_cases:
     patch: '0'
     patch_minor: '25'
 
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8L1 Twitter for iPad'
+    family: 'Twitter'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Nokia 2.1 Build/PKQ1.181105.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 TwitterAndroid'
+    family: 'Twitter'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_1 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Mobile/15C153 Twitter for iPhone/7.19'
+    family: 'Twitter'
+    major: '7'
+    minor: '19'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) GSA/4.2.2.38484 Mobile/11D257 Safari/9537.53'
+    family: 'Google'
+    major: '4'
+    minor: '2'
+    patch: '2'
+
   - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0_2 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) GSA/36.0.169645775 Mobile/15A421 Safari/604.1'
     family: 'Google'
     major: '36'
     minor: '0'
     patch: '169645775'
+
+  - user_agent_string: 'ViaFree-DK/3.8.3 (com.MTGx.ViaFree.dk; build:7383; iOS 12.1.0) Alamofire/4.7.0'
+    family: 'ViaFree'
+    major: '3'
+    minor: '8'
+    patch: '3'
+
+  - user_agent_string: 'Viafree-tvOS-DK/3.7.1 (com.MTGx.ViaFree.dk; build:7341; tvOS 12.1.0) Alamofire/4.7.0'
+    family: 'ViaFree'
+    major: '3'
+    minor: '7'
+    patch: '1'
+
+  - user_agent_string: 'OC/15.0.5071.1000 (Skype for Business)'
+    family: 'Skype'
+    major: '15'
+    minor: '0'
+    patch: '5071'
+    patch_minor: '1000'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.1.0; TA-1024 Build/OPR1.170623.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36 GSA/8.65.5.21.arm64'
+    family: 'Google'
+    major: '8'
+    minor: '65'
+    patch: '5'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G960F Build/R16NW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36 GSA/8.65.5.21.arm64'
+    family: 'Google'
+    major: '8'
+    minor: '65'
+    patch: '5'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PQ1A.181205.006; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36 GSA/8.65.5.21.arm64'
+    family: 'Google'
+    major: '8'
+    minor: '65'
+    patch: '5'
+
+  - user_agent_string: 'Microsoft Office Word 2014'
+    family: 'Word'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Ghost/2.13.1+moya (https://github.com/TryGhost/Ghost)'
+    family: 'Ghost'
+    major: '2'
+    minor: '13'
+    patch: '1'
+
+  - user_agent_string: 'Ghost/2.10.8 (https://github.com/TryGhost/Ghost)'
+    family: 'Ghost'
+    major: '2'
+    minor: '10'
+    patch: '8'
+
+  - user_agent_string: 'PAN GlobalProtect/5.2.4 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/602.1 (KHTML, like Gecko) PanGPUI Version/10.0 Safari/602.1'
+    family: 'GlobalProtect'
+    major: '5'
+    minor: '2'
+    patch: '4'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3763.0 Safari/537.36 Edg/75.0.131.0'
+    family: 'Edge'
+    major: '75'
+    minor: '0'
+    patch: '131'
+    patch_minor: '0'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; CPU OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 TopBuzz com.alex.NewsMaster/8.2.1 (iPad; iOS 12.3.1; en; WIFI)'
+    family: 'TopBuzz'
+    major: '8'
+    minor: '2'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; SM-G950U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36 JsSdk/2 TopBuzz/9.4.3 NetType/4G'
+    family: 'TopBuzz'
+    major: '9'
+    minor: '4'
+    patch: '3'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 9; SM-J737A Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Mobile Safari/537.36 JsSdk/2 TopBuzz/9.1.4 NetType/4G'
+    family: 'TopBuzz'
+    major: '9'
+    minor: '1'
+    patch: '4'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 TopBuzz com.topbuzz.videoen/8.2.2 (iPhone; iOS 10.3.3; en; WIFI; CTRadioAccessTechnologyLTE)'
+    family: 'TopBuzz'
+    major: '8'
+    minor: '2'
+    patch: '2'
+
+  - user_agent_string: 'Snapchat/10.29.1.0 (iPhone10,1; iOS 11.2; gzip)'
+    family: 'Snapchat'
+    major: '10'
+    minor: '29'
+    patch: '1'
+
+  - user_agent_string: 'OgScrper/1.0.0'
+    family: 'OgScrper'
+    major: '1'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'Android: Client/0.0.0-indev (Android SDK built for x86; Android 9)'
+    family: 'Android'
+    major: '9'
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 9; zh-cn; vivo X21 Build/PKQ1.180819.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/9.9 Mobile Safari/537.36'
+    family: 'QQ Browser Mobile'
+    major: '9'
+    minor: '9'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1'
+    family: 'Edge Mobile'
+    major: '41'
+    minor: '1'
+    patch: '35'
+    patch_minor: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1'
+    family: 'Edge Mobile'
+    major: '41'
+    minor: '1'
+    patch: '35'
+    patch_minor: '1'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible;AspiegelBot)'
+    family: 'AspiegelBot'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)'
+    family: 'AspiegelBot'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 QGIS/31100'
+    family: 'QGIS'
+    major: '3'
+    minor: '11'
+    patch: '0'
+
+  - user_agent_string: 'Mozilla/5.0 QGIS/2.18.20'
+    family: 'QGIS'
+    major: '2'
+    minor: '18'
+    patch: '20'
+
+  - user_agent_string: 'JOSM/1.5 (15492 nl) Windows 7 64-Bit Java/1.8.0_221'
+    family: 'JOSM'
+    major: '1'
+    minor: '5'
+    patch:
+
+  - user_agent_string: 'FME/2018.7.34.18312  libcurl/7.57.0 WinSSL zlib/1.2.11 WinIDN libssh2/1.7.0'
+    family: 'FME'
+    major: '2018.7'
+    minor: '34'
+    patch: '18312'
+
+  - user_agent_string: 'GeoEvent Server 10.5.1'
+    family: 'GeoEvent Server'
+    major: '10'
+    minor: '5'
+    patch: '1'
+
+  - user_agent_string: 'ArcGIS Pro 2.4.2 (000000000) - ArcGIS Pro'
+    family: 'ArcGIS Pro'
+    major: '2'
+    minor: '4'
+    patch: '2'
+
+  - user_agent_string: 'ArcGIS Client Using WinInet'
+    family: 'ArcMap'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'ArcGISRuntime-Android/10.3.0 (Android 4.4; armeabi-v7a; SAMSUNG-GT-I9195) arcgis-collector/18.0.3 (00000000-0000-0000-0000-000000000000)'
+    family: 'Collector for ArcGIS'
+    major: '18'
+    minor: '0'
+    patch: '3'
+
+  - user_agent_string: 'ArcGISRuntime-iOS/10.3.0 (iOS 10.2.1; iPad5,4) arcgis-collector/19.0.2 (00000000-0000-0000-0000-000000000000)'
+    family: 'Collector for ArcGIS'
+    major: '19'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'ArcGISRuntime-iOS/100.4 (iOS 11.4; iPad7,6) arcgis-aurora/18.1.0 (00000000-0000-0000-0000-000000000000)'
+    family: 'Collector for ArcGIS'
+    major: '18'
+    minor: '1'
+    patch: '0'
+
+  - user_agent_string: 'ArcGISRuntime-NET/10.3.0 (Windows 10.0.18362; x64; UAP; Windows.Desktop) arcgis-collector/18.0.2 (00000000-0000-0000-0000-000000000000)'
+    family: 'Collector for ArcGIS'
+    major: '18'
+    minor: '0'
+    patch: '2'
+
+  - user_agent_string: 'Collector-Android-10.3.7/ArcGIS.Android-10.2.5/7.0/SAMSUNG-SM-T815'
+    family: 'Collector for ArcGIS'
+    major: '10'
+    minor: '3'
+    patch: '7'
+
+  - user_agent_string: 'Collector-iOS-10.4.0:ArcGISiOS-10.2.4+Collector/13.1.2/iPad5,4'
+    family: 'Collector for ArcGIS'
+    major: '10'
+    minor: '4'
+    patch: '0'
+
+  - user_agent_string: 'Collector/6212016 CFNetwork/978.0.7 Darwin/18.7.0'
+    family: 'Collector for ArcGIS'
+    major: '6212016'
+    minor:
+    patch:
+
+  - user_agent_string: 'ArcGISRuntime-Android/100.2.2 (Android 6.0; armeabi-v7a; SAMSUNG-SM-T800) arcgis-explorer/18.1.0 (00000000-0000-0000-0000-000000000000)'
+    family: 'Explorer for ArcGIS'
+    major: '18'
+    minor: '1'
+    patch: '0'
+
+  - user_agent_string: 'ArcGISRuntime-iOS/100.1 (iPhone OS 9.3.5; iPad2,2) arcgis-explorer/17.1.2 (00000000-0000-0000-0000-000000000000)'
+    family: 'Explorer for ArcGIS'
+    major: '17'
+    minor: '1'
+    patch: '2'
+
+  - user_agent_string: 'Explorer/1544 CFNetwork/1107.1 Darwin/19.0.0'
+    family: 'Explorer for ArcGIS'
+    major: '1544'
+    minor:
+    patch:
+
+  - user_agent_string: 'Explorer-Android-10.2.10/ArcGIS.Android-10.2.8/5.1.1/SAMSUNG-SM-G361F'
+    family: 'Explorer for ArcGIS'
+    major: '10'
+    minor: '2'
+    patch: '10'
+
+  - user_agent_string: 'Explorer-iOS-10.2.10:ArcGISiOS-10.2.4+Collector/13.1.3/iPhone9,3'
+    family: 'Explorer for ArcGIS'
+    major: '10'
+    minor: '2'
+    patch: '10'
+
+  - user_agent_string: 'ArcGISRuntime-Android/100.1.1 (Android 7.0; arm64-v8a; SAMSUNG-SM-G930F) arcgis-workforce/17.0.1 (00000000-0000-0000-0000-000000000000)'
+    family: 'Workforce for ArcGIS'
+    major: '17'
+    minor: '0'
+    patch: '1'
+
+  - user_agent_string: 'Workforce-iOS-17.0.1:ArcGISiOS-100.0.0.1529+dev/13.2/iPad6,12'
+    family: 'Workforce for ArcGIS'
+    major: '17'
+    minor: '0'
+    patch: '1'
+
+  - user_agent_string: 'AR/10.2.6.1704 .Net/Desktop (Win32NT/6.1.7601.65536; Win64) arcgisearth/1.5'
+    family: 'ArcGIS Earth'
+    major: '1'
+    minor: '5'
+    patch:
+
+  - user_agent_string: 'ArcGISRuntime-iOS/100.6 (iOS 12.3.1; iPad6,3) com.esri.earth.phone/1.0.0'
+    family: 'ArcGIS Earth'
+    major: '1'
+    minor: '0'
+    patch: '0'
+
+  - user_agent_string: 'ArcGISiOS-10.2.4/12.1/iPad5,2'
+    family: 'ArcGIS Runtime SDK for iOS'
+    major: '10'
+    minor: '2'
+    patch: '4'
+
+  - user_agent_string: 'ArcGISRuntime-iOS/100.1.1 (iOS 12.4.1; iPhone10,4)'
+    family: 'ArcGIS Runtime SDK for iOS'
+    major: '100'
+    minor: '1'
+    patch: '1'
+
+  - user_agent_string: 'ArcGIS.Android-10.2.4/8.0.0/SAMSUNG-SM-A530F'
+    family: 'ArcGIS Runtime SDK for Android'
+    major: '10'
+    minor: '2'
+    patch: '4'
+
+  - user_agent_string: 'ArcGIS.Android.10.2'
+    family: 'ArcGIS Runtime SDK for Android'
+    major: '10'
+    minor: '2'
+    patch:
+
+  - user_agent_string: 'ArcGISRuntime-Android/100.4 (Android 10.0; arm64-v8a; ONEPLUS-HD1903)'
+    family: 'ArcGIS Runtime SDK for Android'
+    major: '100'
+    minor: '4'
+    patch:
+
+  - user_agent_string: 'ArcGISRuntime-Qt/100.3 (Windows 10; x86_64; Qt 5.12.1; C++)'
+    family: 'ArcGIS Runtime SDK for Qt'
+    major: '100'
+    minor: '3'
+    patch:
+
+  - user_agent_string: 'ArcGISRuntime-NET/100.7 (Windows 10.0.18362; Win64; WOW64; UAP; Windows.Desktop)'
+    family: 'ArcGIS Runtime SDK for NET'
+    major: '100'
+    minor: '7'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.3 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15'
+    family: 'DuckDuckGo Mobile'
+    major: '7'
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile DuckDuckGo/5 Safari/537.36'
+    family: 'DuckDuckGo Mobile'
+    major: '5'
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 [en] (X11, U; OpenVAS-VT 8.0.9)'
+    family: 'OpenVAS Scanner'
+    major: '8'
+    minor: '0'
+    patch: '9'
+
+  - user_agent_string: 'Mozilla/5.0 [en] (X11, U; OpenVAS 7.0.10)'
+    family: 'OpenVAS Scanner'
+    major: '7'
+    minor: '0'
+    patch: '10'
+
+  - user_agent_string: 'Mozilla/4.75 [en] (X11, U; OpenVAS)'
+    family: 'OpenVAS Scanner'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'cf/6.51.0+2acd15650.2020-04-07 (go1.13.8; amd64 linux)'
+    family: 'CloudFoundry'
+    major: '6'
+    minor: '51'
+    patch: '0+2acd15650.2020-04-07'
+
+  - user_agent_string: 'RPT-HTTPClient/0.3-3E'
+    family: 'HTTPClient'
+    major: '0'
+    minor: '3'
+    patch: '3E'
+
+  - user_agent_string: 'CloudCockpitBackend/2.8.7'
+    family: 'CloudCockpitBackend'
+    major: '2'
+    minor: '8'
+    patch: '7'
+
+  - user_agent_string: 'ReactorNetty/0.9.6.RELEASE'
+    family: 'ReactorNetty'
+    major: '0'
+    minor: '9'
+    patch: '6'
+
+  - user_agent_string: 'axios/0.18.1'
+    family: 'axios'
+    major: '0'
+    minor: '18'
+    patch: '1'
+
+  - user_agent_string: 'Jersey/2.29.1 (HttpUrlConnection 1.8.0_252)  '
+    family: 'Jersey'
+    major: '2'
+    minor: '29'
+    patch: '1'
+
+  - user_agent_string: 'Java-EurekaClient/v1.6.2'
+    family: 'Java-EurekaClient'
+    major: '1'
+    minor: '6'
+    patch: '2'
+
+  - user_agent_string: 'go-cli 6.46.0+29d6257f1.2019-07-09 / windows'
+    family: 'go-cli'
+    major: '6'
+    minor: '46'
+    patch: '0+29d6257f1.2019-07-09'
+
+  - user_agent_string: 'Vert.x-WebClient/3.9.0'
+    family: 'Vert.x-WebClient'
+    major: '3'
+    minor: '9'
+    patch: '0'
+
+  - user_agent_string: 'Apache-CXF/3.1.14-sap-07'
+    family: 'Apache-CXF'
+    major: '3'
+    minor: '1'
+    patch: '14'
+
+  - user_agent_string: 'Go-CF-client/1.1'
+    family: 'Go-CF-client'
+    major: '1'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'HTTPClient/1.0 (2.8.3, ruby 2.5.5 (2019-03-15))'
+    family: 'HTTPClient'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'ping-service'
+    family: 'ping-service'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'CloudFoundryJavaClient/unknown (Java; SAP AG/1.8.0_251) ReactorNetty/0.9.6.RELEASE (Netty/4.1.49.Final)'
+    family: 'ReactorNetty'
+    major: '0'
+    minor: '9'
+    patch: '6'
+
+  - user_agent_string: 'lua-resty-http/0.13 (Lua) ngx_lua/10013'
+    family: 'lua-resty-http'
+    major: '0'
+    minor: '13'
+    patch:
+
+  - user_agent_string: 'AHC/1.0'
+    family: 'AHC'
+    major: '1'
+    minor: '0'
+    patch:
+
+  - user_agent_string: 'sap xsuaa'
+    family: 'sap xsuaa'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'sap-leonardo-iot-sdk-nodejs / 0.1.4'
+    family: 'sap-leonardo-iot-sdk-nodejs'
+    major: '0'
+    minor: '1'
+    patch: '4'
+
+  - user_agent_string: 'Node-oauth'
+    family: 'Node-oauth'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'go-resty/1.12.0 (https://github.com/go-resty/resty)'
+    family: 'go-resty'
+    major: '1'
+    minor: '12'
+    patch: '0'
+
+  - user_agent_string: 'Site24x7'
+    family: 'Site24x7'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'SAP NetWeaver Application Server (1.0;740)'
+    family: 'SAP NetWeaver Application Server'
+    major: '7'
+    minor: '40'
+    patch:
+
+  - user_agent_string: 'SAP CPI'
+    family: 'SAP CPI'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'JAEGER_SECURITY'
+    family: 'JAEGER_SECURITY'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 8.1.0; tr; SNE-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Tenta/2.10.3 Mobile Safari/537.36 Mobile'
+    family: 'Tenta Browser'
+    major: '2'
+    minor: '10'
+    patch: '3'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible; monitis - premium monitoring service; http://www.monitis.com)'
+    family: 'Monitis'
+    major:
+    minor:
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E302 Pandora/1902.1'
+    family: 'Pandora'
+    major: '1902'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Pandora/1904.1.3'
+    family: 'Pandora'
+    major: '1904'
+    minor: '1'
+    patch: '3'
+
+  - user_agent_string: 'Pandora/1904.1 Android/8.0.0 heroqlteusc (ExoPlayerLib1.5.14.1)'
+    family: 'Pandora'
+    major: '1904'
+    minor: '1'
+    patch:
+
+  - user_agent_string: 'Pandora/2091 CFNetwork/978.0.7 Darwin/18.5.0'
+    family: 'Pandora'
+    major: '2091'
+    minor:
+    patch:
+
+  - user_agent_string: 'PandoraRSSCrawler/1.0 (podcastpartnerships@pandora.com)'
+    family: 'PandoraRSSCrawler'
+    major:  '1'
+    minor:  '0'
+    patch:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,14 @@ end
     pass = 0
     fail = 0
     for test_case in test_device["test_cases"]
-        test_case["family"] == parsedevice(test_case["user_agent_string"]).family ? pass += 1 : fail += 1
+        old_fail = fail
+        str = test_case["user_agent_string"]
+        dev = parsedevice(str)
+        test_case["family"] == dev.family ? pass += 1 : fail += 1
+        fail == old_fail || @info """When parsing device for "$str", expect $test_case, but got $dev"""
     end
 
-    @test pass/(pass + fail) >= .945
+    @test pass/(pass + fail) >= 0.999
 
 end
 
@@ -37,15 +41,18 @@ end
     pass = 0
     fail = 0
 
-    for value in test_os["test_cases"]
-        os = parseos(value["user_agent_string"])
-        value["family"] == os.family ? pass += 1 : fail += 1
-        (@testparseval value "major" os) ? pass += 1 : fail += 1
-        (@testparseval value "minor" os) ? pass += 1 : fail += 1
-        (@testparseval value "patch_minor" os) ? pass += 1 : fail += 1
+    for test_case in test_os["test_cases"]
+        old_fail = fail
+        str = test_case["user_agent_string"]
+        os = parseos(str)
+        test_case["family"] == os.family ? pass += 1 : fail += 1
+        (@testparseval test_case "major" os) ? pass += 1 : fail += 1
+        (@testparseval test_case "minor" os) ? pass += 1 : fail += 1
+        (@testparseval test_case "patch_minor" os) ? pass += 1 : fail += 1
+        fail == old_fail || @info """When parsing os for "$str", expect $test_case, but got $os"""
     end
 
-    @test pass/(pass + fail) >= .992
+    @test pass/(pass + fail) >= 0.999
 
 end
 
@@ -56,14 +63,17 @@ end
     pass = 0
     fail = 0
 
-    for value in test_ua["test_cases"]
-        ua = parseuseragent(value["user_agent_string"])
-        value["family"] == ua.family ? pass += 1 : fail += 1
-        (@testparseval value "major" ua) ? pass += 1 : fail += 1
-        (@testparseval value "minor" ua) ? pass += 1 : fail += 1
-        (@testparseval value "patch" ua) ? pass += 1 : fail += 1
+    for test_case in test_ua["test_cases"]
+        old_fail = fail
+        str = test_case["user_agent_string"]
+        ua = parseuseragent(str)
+        test_case["family"] == ua.family ? pass += 1 : fail += 1
+        (@testparseval test_case "major" ua) ? pass += 1 : fail += 1
+        (@testparseval test_case "minor" ua) ? pass += 1 : fail += 1
+        (@testparseval test_case "patch" ua) ? pass += 1 : fail += 1
+        fail == old_fail || @info """When parsing ua for "$str", expect $test_case, but got $ua"""
     end
 
-    @test pass/(pass + fail) >= .992
+    @test pass/(pass + fail) >= 0.999
 
 end


### PR DESCRIPTION
Fixed functions and there is no problem with uap-core v0.10.0. Do not that, however, uap-core v0.13.0 contains test cases not covered by its regex set, so updating to uap-core v0.13.0 will make the accuracy less than 100%.